### PR TITLE
add option to provide package specific flags in YAML

### DIFF
--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -54,9 +54,9 @@ else
 fi
 
 export F9X=$FC
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export FFLAGS="${STACK_esmf_FFLAGS} -fPIC"
+export CFLAGS="${STACK_esmf_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_esmf_CXXFLAGS} -fPIC"
 export FCFLAGS="$FFLAGS"
 
 gitURL="https://github.com/esmf-org/esmf"

--- a/libs/build_fftw.sh
+++ b/libs/build_fftw.sh
@@ -38,8 +38,8 @@ else
 fi
 
 export F77=$FC
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
+export FFLAGS="${STACK_fftw_FFLAGS} -fPIC"
+export CFLAGS="${STACK_fftw_CFLAGS} -fPIC"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -44,9 +44,9 @@ else
 fi
 
 export F9X=$FC
-export FFLAGS="-fPIC -w"
-export CFLAGS="-fPIC -w"
-export CXXFLAGS="-fPIC -w"
+export FFLAGS="${STACK_hdf5_FFLAGS} -fPIC -w"
+export CFLAGS="${STACK_hdf5_CFLAGS} -fPIC -w"
+export CXXFLAGS="${STACK_hdf5_CXXFLAGS} -fPIC -w"
 export FCFLAGS="$FFLAGS"
 
 gitURL="https://bitbucket.hdfgroup.org/scm/hdffv/hdf5.git"

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -30,8 +30,8 @@ export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 
 export F77=$FC
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
+export FFLAGS="${STACK_jasper_FFLAGS} -fPIC"
+export CFLAGS="${STACK_jasper_CFLAGS} -fPIC"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -27,7 +27,7 @@ else
 fi
 
 export CC=$SERIAL_CC
-export CFLAGS="-fPIC"
+export CFLAGS="${STACK_jpeg_CFLAGS} -fPIC"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_lapack.sh
+++ b/libs/build_lapack.sh
@@ -30,9 +30,10 @@ export FC=$SERIAL_FC
 export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
-export FCFLAGS="-fPIC"
+export FFLAGS="${STACK_lapack_FFLAGS} -fPIC"
+export CFLAGS="${STACK_lapack_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_lapack_CXXFLAGS} -fPIC"
+export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_mpi.sh
+++ b/libs/build_mpi.sh
@@ -37,9 +37,10 @@ export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 export FC=$SERIAL_FC
 
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
-export FCFLAGS="-fPIC"
+export FFLAGS="${STACK_mpi_FFLAGS} -fPIC"
+export CFLAGS="${STACK_mpi_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_mpi_CXXFLAGS} -fPIC"
+export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"../pkg"}
 

--- a/libs/build_nccmp.sh
+++ b/libs/build_nccmp.sh
@@ -46,7 +46,7 @@ else
     export CXX=$SERIAL_CXX
 fi
 
-export CFLAGS="-fPIC"
+export CFLAGS="${STACK_nccmp_CFLAGS} -fPIC"
 LDFLAGS1="-L$HDF5_ROOT/lib -lhdf5_hl -lhdf5"
 LDFLAGS2=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
 LDFLAGS3=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -110,10 +110,14 @@ else
   export CXX=$SERIAL_CXX
 fi
 
+eval fflags="\${STACK_${name}_FFLAGS}"
+eval cflags="\${STACK_${name}_CFLAGS}"
+eval cxxflags="\${STACK_${name}_CXXFLAGS}"
+
 export F9X=$FC
-export FFLAGS="-fPIC -w"
-export CFLAGS="-fPIC -w"
-export CXXFLAGS="-fPIC -w"
+export FFLAGS="$fflags -fPIC -w"
+export CFLAGS="$cflags -fPIC -w"
+export CXXFLAGS="$cxxflags -fPIC -w"
 export FCFLAGS="$FFLAGS"
 
 # Set properties based on library name

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -47,9 +47,9 @@ else
     export CXX=$SERIAL_CXX
 fi
 
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export FFLAGS="${STACK_nco_FFLAGS} -fPIC"
+export CFLAGS="${STACK_nco_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_nco_CXXFLAGS} -fPIC"
 
 export F77=$FC
 export FCFLAGS=$FFLAGS

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -48,9 +48,9 @@ fi
 
 export F77=$FC
 export F9X=$FC
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC -std=c++11"
+export FFLAGS="${STACK_netcdf_FFLAGS} -fPIC"
+export CFLAGS="${STACK_netcdf_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_netcdf_CXXFLAGS} -fPIC -std=c++11"
 export FCFLAGS="$FFLAGS"
 
 gitURLroot="https://github.com/Unidata"

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -38,9 +38,9 @@ export CC=$MPI_CC
 export CXX=$MPI_CXX
 
 export F9X=$FC
-export FFLAGS="-fPIC"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export FFLAGS="${STACK_pio_FFLAGS} -fPIC"
+export CFLAGS="${STACK_pio_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_pio_CXXFLAGS} -fPIC"
 export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}

--- a/libs/build_pnetcdf.sh
+++ b/libs/build_pnetcdf.sh
@@ -32,9 +32,9 @@ export CXX=$MPI_CXX
 
 export F77=$FC
 export F9X=$FC
-export FFLAGS="-fPIC -w"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export FFLAGS="${STACK_pnetcdf_FFLAGS} -fPIC -w"
+export CFLAGS="${STACK_pnetcdf_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_pnetcdf_CXXFLAGS} -fPIC"
 export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -30,7 +30,7 @@ else
 fi
 
 export CC=$SERIAL_CC
-export CFLAGS="-fPIC"
+export CFLAGS="${STACK_png_CFLAGS} -fPIC"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_szip.sh
+++ b/libs/build_szip.sh
@@ -32,9 +32,10 @@ export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 export FC=$SERIAL_FC
 
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
-export FCFLAGS="-fPIC"
+export FFLAGS="${STACK_szip_FFLAGS} -fPIC"
+export CFLAGS="${STACK_szip_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_szip_CXXFLAGS} -fPIC"
+export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -30,8 +30,9 @@ export FC=$SERIAL_FC
 export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 
-export FCFLAGS="-fPIC"
-export CFLAGS="-fPIC"
+export FFLAGS="${STACK_udunits_FFLAGS} -fPIC"
+export CFLAGS="${STACK_udunits_CFLAGS} -fPIC"
+export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/libs/build_zlib.sh
+++ b/libs/build_zlib.sh
@@ -29,9 +29,10 @@ export FC=$SERIAL_FC
 export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 
-export FCFLAGS="-fPIC"
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export FFLAGS="${STACK_zlib_FFLAGS} -fPIC"
+export CFLAGS="${STACK_zlib_CFLAGS} -fPIC"
+export CXXFLAGS="${STACK_zlib_CXXFLAGS} -fPIC"
+export FCFLAGS="$FFLAGS"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 


### PR DESCRIPTION
previously, all flags had to be specified in the build script for the package.
This PR enables the user to provide common flags via `CFLAGS`, `FFLAGS` or `CXXFLAGS` in the yaml file in the package section.

An example use would be when building with `gfortran-10`, the user must set the following `-fallow-argument-mismatch -fallow-invalid-boz`

One could also think about (in a later PR), if a "stack-wide" compiler flag setting is appropriate, but that could be potentially dangerous with unintended consequences.