### PR TITLE
Add w3nco dependency to prod_util

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -97,6 +97,9 @@ if $MODULES; then
       module load ip
       module load sp
       ;;
+   prod_util)
+      module load w3nco
+      ;;
   esac
   module list
   set -x

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -97,7 +97,7 @@ if $MODULES; then
       module load ip
       module load sp
       ;;
-   prod_util)
+    prod_util)
       module load w3nco
       ;;
   esac


### PR DESCRIPTION
prod_util depends on w3nco. I don't know why this failure hasn't shown up in other builds? 

https://github.com/NOAA-EMC/NCEPLIBS-prod_util/blob/b5674bb870bd336fa69bf6c35cf7c77a5dc2e462/CMakeLists.txt#L29