### PR TITLE
Add ability to build esmf with debug option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These `hpc-` modules are really meta-modules that will both load the compiler/mp
 
 So, in short, you should never load the compiler or MPI modules directly.  Instead, you should always load the `hpc-` meta-modules as demonstrated above - they will provide everything you need to load and then use these software libraries.
 
-If the compiler and/or MPI is natively available on the system and the user wishes to make use of it e.g. `/usr/bin/gcc`, the `setup_modules.sh` script prompts the user to answer questions regarding their use.  For e.g. in containers, one would like to use the system provided GNU compilers, but build a MPI implementation. 
+If the compiler and/or MPI is natively available on the system and the user wishes to make use of it e.g. `/usr/bin/gcc`, the `setup_modules.sh` script prompts the user to answer questions regarding their use.  For e.g. in containers, one would like to use the system provided GNU compilers, but build a MPI implementation.
 
 ## Step 3: Build Software Stack
 

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -108,6 +108,7 @@ mkdir -p $logdir
 
 # start with a clean slate
 if $MODULES; then
+  source $MODULESHOME/init/bash
   module use $PREFIX/modulefiles/stack
   module load hpc
 else

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -71,9 +71,10 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_00
+  version: 8_1_0_beta_snapshot_21
   shared: YES
   enable_pnetcdf: NO
+  debug: NO
 
 gptl:
   build: NO

--- a/config/stack_hera.yaml
+++ b/config/stack_hera.yaml
@@ -67,9 +67,10 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_00
+  version: 8_1_0_beta_snapshot_21
   shared: NO
   enable_pnetcdf: NO
+  debug: NO
 
 gptl:
   build: NO

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -71,9 +71,10 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_00
+  version: 8_1_0_beta_snapshot_21
   shared: YES
   enable_pnetcdf: NO
+  debug: NO
 
 gptl:
   build: NO

--- a/config/stack_orion.yaml
+++ b/config/stack_orion.yaml
@@ -67,9 +67,10 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_00
+  version: 8_1_0_beta_snapshot_21
   shared: NO
   enable_pnetcdf: NO
+  debug: NO
 
 gptl:
   build: NO

--- a/config/stack_wcoss_dell_p3.yaml
+++ b/config/stack_wcoss_dell_p3.yaml
@@ -67,9 +67,10 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_00
+  version: 8_1_0_beta_snapshot_21
   shared: NO
   enable_pnetcdf: NO
+  debug: NO
 
 gptl:
   build: NO


### PR DESCRIPTION
This PR:
- shows how one can build a package in debug mode (e.g. esmf).  Set `debug: YES|NO` in the `esmf` dictionary section of the yaml file. 
- The modulefile and prefix install directory will append `-debug` to the `version`
- The `debug` and `default` packages can be installed side-by-side.

When modules are not used, the `prefix`and `debug` does not matter because packages are installed in a single `prefix`.

