### PR TITLE
Update NCEPLIBS and enable OpenMP for SP

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -90,86 +90,86 @@ tau2:
 
 bacio:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sigio:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.2
+  install_as: 2.3.2
   openmp: OFF
 
 sfcio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 gfsio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 w3nco:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sp:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.1
+  install_as: 2.3.1
   openmp: OFF
 
 ip:
   build: YES
-  version: v3.3.0
-  install_as: 3.3.0
+  version: v3.3.1
+  install_as: 3.3.1
   openmp: OFF
 
 ip2:
   build: NO
-  version: v1.1.0
-  install_as: 1.1.0
+  version: v1.1.1
+  install_as: 1.1.1
   openmp: OFF
 
 landsfcutil:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  openmp: OFF
+
+nemsiogfs:
   build: YES
   version: v2.5.1
   install_as: 2.5.1
   openmp: OFF
 
-nemsiogfs:
-  build: YES
-  version: v2.5.0
-  install_as: 2.5.0
-  openmp: OFF
-
 w3emc:
   build: YES
-  version: v2.7.0
-  install_as: 2.7.0
+  version: v2.7.1
+  install_as: 2.7.1
   openmp: OFF
 
 g2:
   build: YES
-  version: v3.4.0
-  install_as: 3.4.0
+  version: v3.4.1
+  install_as: 3.4.1
   openmp: OFF
 
 g2tmpl:
   build: YES
-  version: v1.9.0
-  install_as: 1.9.0
+  version: v1.9.1
+  install_as: 1.9.1
   openmp: OFF
 
 crtm:
@@ -186,14 +186,14 @@ nceppost:
 
 wrf_io:
   build: YES
-  version: v1.1.1-cmake
+  version: v1.1.1-cmake-v2
   install_as: 1.1.1
   openmp: OFF
 
 bufr:
   build: YES
-  version: bufr_v11.3.1.1
-  install_as: 11.3.1.1
+  version: bufr_v11.4.0
+  install_as: 11.4.0
   openmp: OFF
 
 wgrib2:

--- a/config/stack_hera.yaml
+++ b/config/stack_hera.yaml
@@ -86,86 +86,86 @@ tau2:
 
 bacio:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sigio:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.2
+  install_as: 2.3.2
   openmp: OFF
 
 sfcio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 gfsio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 w3nco:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sp:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
-  openmp: OFF
+  version: v2.3.1
+  install_as: 2.3.1
+  openmp: ON
 
 ip:
   build: YES
-  version: v3.3.0
-  install_as: 3.3.0
+  version: v3.3.1
+  install_as: 3.3.1
   openmp: OFF
 
 ip2:
-  build: YES
-  version: v1.1.0
-  install_as: 1.1.0
+  build: NO
+  version: v1.1.1
+  install_as: 1.1.1
   openmp: OFF
 
 landsfcutil:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  openmp: OFF
+
+nemsiogfs:
   build: YES
   version: v2.5.1
   install_as: 2.5.1
   openmp: OFF
 
-nemsiogfs:
-  build: YES
-  version: v2.5.0
-  install_as: 2.5.0
-  openmp: OFF
-
 w3emc:
   build: YES
-  version: v2.7.0
-  install_as: 2.7.0
+  version: v2.7.1
+  install_as: 2.7.1
   openmp: OFF
 
 g2:
   build: YES
-  version: v3.4.0
-  install_as: 3.4.0
+  version: v3.4.1
+  install_as: 3.4.1
   openmp: OFF
 
 g2tmpl:
   build: YES
-  version: v1.9.0
-  install_as: 1.9.0
+  version: v1.9.1
+  install_as: 1.9.1
   openmp: OFF
 
 crtm:
@@ -182,14 +182,14 @@ nceppost:
 
 wrf_io:
   build: YES
-  version: v1.1.1-cmake
+  version: v1.1.1-cmake-v2
   install_as: 1.1.1
   openmp: OFF
 
 bufr:
   build: YES
-  version: bufr_v11.3.1.1
-  install_as: 11.3.1.1
+  version: bufr_v11.4.0
+  install_as: 11.4.0
   openmp: OFF
 
 wgrib2:

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -90,86 +90,86 @@ tau2:
 
 bacio:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sigio:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.2
+  install_as: 2.3.2
   openmp: OFF
 
 sfcio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 gfsio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 w3nco:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sp:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
-  openmp: OFF
+  version: v2.3.1
+  install_as: 2.3.1
+  openmp: ON
 
 ip:
   build: YES
-  version: v3.3.0
-  install_as: 3.3.0
+  version: v3.3.1
+  install_as: 3.3.1
   openmp: OFF
 
 ip2:
   build: NO
-  version: v1.1.0
-  install_as: 1.1.0
+  version: v1.1.1
+  install_as: 1.1.1
   openmp: OFF
 
 landsfcutil:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  openmp: OFF
+
+nemsiogfs:
   build: YES
   version: v2.5.1
   install_as: 2.5.1
   openmp: OFF
 
-nemsiogfs:
-  build: YES
-  version: v2.5.0
-  install_as: 2.5.0
-  openmp: OFF
-
 w3emc:
   build: YES
-  version: v2.7.0
-  install_as: 2.7.0
+  version: v2.7.1
+  install_as: 2.7.1
   openmp: OFF
 
 g2:
   build: YES
-  version: v3.4.0
-  install_as: 3.4.0
+  version: v3.4.1
+  install_as: 3.4.1
   openmp: OFF
 
 g2tmpl:
   build: YES
-  version: v1.9.0
-  install_as: 1.9.0
+  version: v1.9.1
+  install_as: 1.9.1
   openmp: OFF
 
 crtm:
@@ -186,14 +186,14 @@ nceppost:
 
 wrf_io:
   build: YES
-  version: v1.1.1-cmake
+  version: v1.1.1-cmake-v2
   install_as: 1.1.1
   openmp: OFF
 
 bufr:
   build: YES
-  version: bufr_v11.3.1.1
-  install_as: 11.3.1.1
+  version: bufr_v11.4.0
+  install_as: 11.4.0
   openmp: OFF
 
 wgrib2:

--- a/config/stack_orion.yaml
+++ b/config/stack_orion.yaml
@@ -86,86 +86,86 @@ tau2:
 
 bacio:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sigio:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.2
+  install_as: 2.3.2
   openmp: OFF
 
 sfcio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 gfsio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 w3nco:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sp:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
-  openmp: OFF
+  version: v2.3.1
+  install_as: 2.3.1
+  openmp: ON
 
 ip:
   build: YES
-  version: v3.3.0
-  install_as: 3.3.0
+  version: v3.3.1
+  install_as: 3.3.1
   openmp: OFF
 
 ip2:
-  build: YES
-  version: v1.1.0
-  install_as: 1.1.0
+  build: NO
+  version: v1.1.1
+  install_as: 1.1.1
   openmp: OFF
 
 landsfcutil:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  openmp: OFF
+
+nemsiogfs:
   build: YES
   version: v2.5.1
   install_as: 2.5.1
   openmp: OFF
 
-nemsiogfs:
-  build: YES
-  version: v2.5.0
-  install_as: 2.5.0
-  openmp: OFF
-
 w3emc:
   build: YES
-  version: v2.7.0
-  install_as: 2.7.0
+  version: v2.7.1
+  install_as: 2.7.1
   openmp: OFF
 
 g2:
   build: YES
-  version: v3.4.0
-  install_as: 3.4.0
+  version: v3.4.1
+  install_as: 3.4.1
   openmp: OFF
 
 g2tmpl:
   build: YES
-  version: v1.9.0
-  install_as: 1.9.0
+  version: v1.9.1
+  install_as: 1.9.1
   openmp: OFF
 
 crtm:
@@ -182,14 +182,14 @@ nceppost:
 
 wrf_io:
   build: YES
-  version: v1.1.1-cmake
+  version: v1.1.1-cmake-v2
   install_as: 1.1.1
   openmp: OFF
 
 bufr:
   build: YES
-  version: bufr_v11.3.1.1
-  install_as: 11.3.1.1
+  version: bufr_v11.4.0
+  install_as: 11.4.0
   openmp: OFF
 
 wgrib2:

--- a/config/stack_wcoss_dell_p3.yaml
+++ b/config/stack_wcoss_dell_p3.yaml
@@ -86,86 +86,86 @@ tau2:
 
 bacio:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sigio:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.3.2
+  install_as: 2.3.2
   openmp: OFF
 
 sfcio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 gfsio:
   build: YES
-  version: v1.4.0
-  install_as: 1.4.0
+  version: v1.4.1
+  install_as: 1.4.1
   openmp: OFF
 
 w3nco:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 sp:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
-  openmp: OFF
+  version: v2.3.1
+  install_as: 2.3.1
+  openmp: ON
 
 ip:
   build: YES
-  version: v3.3.0
-  install_as: 3.3.0
+  version: v3.3.1
+  install_as: 3.3.1
   openmp: OFF
 
 ip2:
-  build: YES
-  version: v1.1.0
-  install_as: 1.1.0
+  build: NO
+  version: v1.1.1
+  install_as: 1.1.1
   openmp: OFF
 
 landsfcutil:
   build: YES
-  version: v2.4.0
-  install_as: 2.4.0
+  version: v2.4.1
+  install_as: 2.4.1
   openmp: OFF
 
 nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  openmp: OFF
+
+nemsiogfs:
   build: YES
   version: v2.5.1
   install_as: 2.5.1
   openmp: OFF
 
-nemsiogfs:
-  build: YES
-  version: v2.5.0
-  install_as: 2.5.0
-  openmp: OFF
-
 w3emc:
   build: YES
-  version: v2.7.0
-  install_as: 2.7.0
+  version: v2.7.1
+  install_as: 2.7.1
   openmp: OFF
 
 g2:
   build: YES
-  version: v3.4.0
-  install_as: 3.4.0
+  version: v3.4.1
+  install_as: 3.4.1
   openmp: OFF
 
 g2tmpl:
   build: YES
-  version: v1.9.0
-  install_as: 1.9.0
+  version: v1.9.1
+  install_as: 1.9.1
   openmp: OFF
 
 crtm:
@@ -182,14 +182,14 @@ nceppost:
 
 wrf_io:
   build: YES
-  version: v1.1.1-cmake
+  version: v1.1.1-cmake-v2
   install_as: 1.1.1
   openmp: OFF
 
 bufr:
   build: YES
-  version: bufr_v11.3.1.1
-  install_as: 11.3.1.1
+  version: bufr_v11.4.0
+  install_as: 11.4.0
   openmp: OFF
 
 wgrib2:


### PR DESCRIPTION
OpenMP is important for SP so enable it for all the HPC configs.

NCEPLIBS fixes for GCC 10, cleanup CMakeLists, and remove -xHOST from certain libraries