### PR TITLE
no modules functionality requires setting PATH etc.

### DIFF
--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -26,8 +26,6 @@ jobs:
       run: |
         cd ${{ matrix.compiler }}-${{ matrix.mpi }}
         prefix=$GITHUB_WORKSPACE/install-${{ matrix.compiler }}-${{ matrix.mpi }}
-        export PATH="$prefix/bin:$PATH"
-        export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
         if [[ ${{ matrix.compiler }} == "gcc" ]]; then
           export CC=/usr/local/bin/gcc-9
           export CXX=/usr/local/bin/g++-9

--- a/.github/workflows/build_ubuntu.yaml
+++ b/.github/workflows/build_ubuntu.yaml
@@ -33,8 +33,6 @@ jobs:
       run: |
         cd ${{ matrix.mpi }}
         prefix=$GITHUB_WORKSPACE/install-${{ matrix.mpi }}
-        export PATH="$prefix/bin:$PATH"
-        export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
         if [[ ${{ matrix.mpi }} == "mpich" ]]; then
           mpi_ver=$( mpiexec --version | grep Version | awk '{ print $2 }' )
         elif [[ ${{ matrix.mpi }} == "openmpi" ]]; then

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ This will put the `hpc-<compilerName>` module in your `MODULEPATH`, which can be
 ```
 module load hpc-<compilerName>/<compilerVersion>
 ```
+- If the HPC-stack is not managed via modules, you need to add `$PREFIX` to the PATH as follows:
+```
+export PATH="$PREFIX/bin:$PATH"
+export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
+export CMAKE_PREFIX_PATH="$PREFIX"
+```
 
 ### Known work-around's for certain installations of Lmod.
 - On some machine's (e.g. **WCOSS_DELL_P3**), LMod is built to disable loading of default modulefiles and requires the user to load the module with an explicit version of the module.  e.g. `module load netcdf/4.7.4` instead of `module load netcdf`. The latter looks for the `default` module which is either the latest version or a version that is marked as default.  To circumvent this, it is necessary to place the following lines in `modulefiles/stack/hpc/hpc.lua` prior to executing `setup_modules.sh` or in `$PREFIX/modulefiles/stack/hpc/1.0.0.lua` after executing `setup_modules.sh`.

--- a/README.md
+++ b/README.md
@@ -168,12 +168,6 @@ This will put the `hpc-<compilerName>` module in your `MODULEPATH`, which can be
 ```
 module load hpc-<compilerName>/<compilerVersion>
 ```
-- If the HPC-stack is not managed via modules, you need to add `$PREFIX` to the PATH as follows:
-```
-export PATH="$PREFIX/bin:$PATH"
-export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
-export CMAKE_PREFIX_PATH="$PREFIX"
-```
 
 ### Known work-around's for certain installations of Lmod.
 - On some machine's (e.g. **WCOSS_DELL_P3**), LMod is built to disable loading of default modulefiles and requires the user to load the module with an explicit version of the module.  e.g. `module load netcdf/4.7.4` instead of `module load netcdf`. The latter looks for the `default` module which is either the latest version or a version that is marked as default.  To circumvent this, it is necessary to place the following lines in `modulefiles/stack/hpc/hpc.lua` prior to executing `setup_modules.sh` or in `$PREFIX/modulefiles/stack/hpc/1.0.0.lua` after executing `setup_modules.sh`.

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -113,6 +113,7 @@ if $MODULES; then
   module load hpc
 else
   no_modules
+  set_no_modules_path
   set_pkg_root
 fi
 

--- a/modulefiles/compiler/compilerName/compilerVersion/mpich/mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/mpich/mpich.lua
@@ -17,8 +17,6 @@ family("mpi")
 conflict(pkgName)
 conflict("openmpi","impi")
 
-try_load("szip")
-
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/core/mkl/mkl.lua
+++ b/modulefiles/core/mkl/mkl.lua
@@ -1,0 +1,35 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+local base = pathJoin("/opt/intel", "compilers_and_libraries_" .. pkgVersion, "mac")
+
+setenv("MKLROOT", pathJoin(base,"mkl"))
+setenv("MKL_ROOT", pathJoin(base,"mkl"))
+setenv("NLSPATH", pathJoin(base,"mkl/lib/locale/%l_%t/%N"))
+
+prepend_path("CPATH",  pathJoin(base,"mkl/include"))
+
+prepend_path("LIBRARY_PATH", pathJoin(base,"tbb/lib"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"compiler/lib"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"mkl/lib"))
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"tbb/lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"compiler/lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"mkl/lib"))
+
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"tbb/lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"compiler/lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"mkl/lib"))
+
+prepend_path("PKG_CONFIG_PATH", pathJoin(base,"mkl/bin/pkgconfig"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Library")
+whatis("Description: Intel Math Kernal Library")

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -124,10 +124,12 @@ function set_pkg_root() {
 
 function set_no_modules_path() {
   # add $PREFIX to PATH, LD_LIBRARY_PATH and CMAKE_PREFIX_PATH
+  set +u
   prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
-  export PATH="$prefix/bin:$PATH"
-  export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
+  export PATH="$prefix/bin:${PATH:-}"
+  export LD_LIBRARY_PATH=$prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   #export CMAKE_PREFIX_PATH=$prefix
+  set -u
 }
 
 function build_lib() {

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -122,6 +122,14 @@ function set_pkg_root() {
   done
 }
 
+function set_no_modules_path() {
+  # add $PREFIX to PATH, LD_LIBRARY_PATH and CMAKE_PREFIX_PATH
+  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
+  export PATH="$prefix/bin:$PATH"
+  export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
+  export CMAKE_PREFIX_PATH=$prefix
+}
+
 function build_lib() {
   # Args: build_script_name
   set +x
@@ -184,6 +192,7 @@ function parse_yaml {
 export -f update_modules
 export -f no_modules
 export -f set_pkg_root
+export -f set_no_modules_path
 export -f build_lib
 export -f build_nceplib
 export -f parse_yaml

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -1,152 +1,170 @@
 #!/bin/bash
 
 function update_modules {
-    PREFIX=${PREFIX:-${OPT}}
-    case $1 in
-        core )
-            tmpl_file=$HPC_STACK_ROOT/modulefiles/core/$2/$2.lua
-            to_dir=$PREFIX/modulefiles/core ;;
-        compiler )
-            tmpl_file=$HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/$2/$2.lua
-            to_dir=$PREFIX/modulefiles/compiler/$HPC_COMPILER ;;
-        mpi )
-            tmpl_file=$HPC_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$2/$2.lua
-            to_dir=$PREFIX/modulefiles/mpi/$HPC_COMPILER/$HPC_MPI ;;
-        * ) echo "ERROR: INVALID MODULE PATH, ABORT!"; exit 1 ;;
-    esac
+  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
+  modpath=$1
+  name=$2
+  version=$3
+  case $modpath in
+    core )
+      tmpl_file=$HPC_STACK_ROOT/modulefiles/core/$name/$name.lua
+      to_dir=$prefix/modulefiles/core
+      ;;
+    compiler )
+      tmpl_file=$HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/$name/$name.lua
+      to_dir=$prefix/modulefiles/compiler/$HPC_COMPILER
+      ;;
+    mpi )
+      tmpl_file=$HPC_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$name/$name.lua
+      to_dir=$prefix/modulefiles/mpi/$HPC_COMPILER/$HPC_MPI
+      ;;
+    * )
+      echo "ERROR: INVALID MODULE PATH, ABORT!"
+      exit 1
+      ;;
+  esac
 
-    [[ -e $tmpl_file ]] || ( echo "ERROR: $tmpl_file NOT FOUND!  ABORT!"; exit 1 )
+  [[ -e $tmpl_file ]] || ( echo "ERROR: $tmpl_file NOT FOUND! ABORT!"; exit 1 )
+  [[ -d $to_dir ]] || ( echo "ERROR: $mod_dir MODULE DIRECTORY NOT FOUND! ABORT!"; exit 1 )
 
-    [[ -d $to_dir ]] || ( echo "ERROR: $mod_dir MODULE DIRECTORY NOT FOUND!  ABORT!"; exit 1 )
+  cd $to_dir
+  $SUDO mkdir -p $name; cd $name
+  $SUDO cp $tmpl_file $version.lua
 
-    cd $to_dir
-    $SUDO mkdir -p $2; cd $2
-    $SUDO cp $tmpl_file $3.lua
-
-    # Make the latest installed version the default
-    [[ -e default ]] && $SUDO rm -f default
-    $SUDO ln -s $3.lua default
-
+  # Make the latest installed version the default
+  [[ -e default ]] && $SUDO rm -f default
+  $SUDO ln -s $version.lua default
 }
 
 function no_modules {
 
-    # this function defines environment variables that are
-    # normally done by the modules.
-    # It's mainly intended for use when not using LMod
+  # this function defines environment variables that are
+  # normally done by the modules.
+  # It's mainly intended for use when not using LMod
 
-    compilerName=$(echo $HPC_COMPILER | cut -d/ -f1)
-    mpiName=$(echo $HPC_MPI | cut -d/ -f1)
+  compilerName=$(echo $HPC_COMPILER | cut -d/ -f1)
+  mpiName=$(echo $HPC_MPI | cut -d/ -f1)
 
-    # these can be specified in the config file
-    # so these should be considered defaults
+  # these can be specified in the config file
+  # so these should be considered defaults
 
-    case $compilerName in
-      gnu|gcc )
-          export SERIAL_CC=${SERIAL_CC:-"gcc"}
-          export SERIAL_CXX=${SERIAL_CXX:-"g++"}
-          export SERIAL_FC=${SERIAL_FC:-"gfortran"}
-          ;;
-      intel|ips )
-          export SERIAL_CC=${SERIAL_CC:-"icc"}
-          export SERIAL_CXX=${SERIAL_CXX:-"icpc"}
-          export SERIAL_FC=${SERIAL_FC:-"ifort"}
-          ;;
-      clang )
-          export SERIAL_CC=${SERIAL_CC:-"clang"}
-          export SERIAL_CXX=${SERIAL_CXX:-"clang++"}
-          export SERIAL_FC=${SERIAL_FC:-"gfortran"}
-          ;;
-      * ) echo "Unknown compiler option = $compilerName, ABORT!"; exit 1 ;;
-    esac
+  case $compilerName in
+    gnu|gcc )
+      export SERIAL_CC=${SERIAL_CC:-"gcc"}
+      export SERIAL_CXX=${SERIAL_CXX:-"g++"}
+      export SERIAL_FC=${SERIAL_FC:-"gfortran"}
+      ;;
+    intel|ips )
+      export SERIAL_CC=${SERIAL_CC:-"icc"}
+      export SERIAL_CXX=${SERIAL_CXX:-"icpc"}
+      export SERIAL_FC=${SERIAL_FC:-"ifort"}
+      ;;
+    clang )
+      export SERIAL_CC=${SERIAL_CC:-"clang"}
+      export SERIAL_CXX=${SERIAL_CXX:-"clang++"}
+      export SERIAL_FC=${SERIAL_FC:-"gfortran"}
+      ;;
+    cray | cray* )
+      export SERIAL_CC=${SERIAL_CC:-"cc"}
+      export SERIAL_CXX=${SERIAL_CXX:-"CC"}
+      export SERIAL_FC=${SERIAL_FC:-"ftn"}
+      ;;
+    * )
+      echo "Unknown compiler option = $compilerName, ABORT!"
+      exit 1
+      ;;
+  esac
 
-    echo "=========================="
-    echo "C Compiler: $SERIAL_CC"
-    echo "C++ Compiler: $SERIAL_CXX"
-    echo "Fortran Compiler: $SERIAL_FC"
-    echo "=========================="
+  echo "=========================="
+  echo "C Compiler: $SERIAL_CC"
+  echo "C++ Compiler: $SERIAL_CXX"
+  echo "Fortran Compiler: $SERIAL_FC"
+  echo "=========================="
 
-    case $mpiName in
-      openmpi)
-          export MPI_CC=${MPI_CC:-"mpicc"}
-          export MPI_CXX=${MPI_CXX:-"mpicxx"}
-          export MPI_FC=${MPI_FC:-"mpifort"}
-          ;;
-      mpich )
-          export MPI_CC=${MPI_CC:-"mpicc"}
-          export MPI_CXX=${MPI_CXX:-"mpicxx"}
-          export MPI_FC=${MPI_FC:-"mpifort"}
-          ;;
-      impi )
-          export MPI_CC=${MPI_CC:-"mpiicc"}
-          export MPI_CXX=${MPI_CXX:-"mpiicpc"}
-          export MPI_FC=${MPI_FC:-"mpiifort"}
-          ;;
-      * ) echo "Unknown MPI option = $mpiName, ABORT!"; exit 1 ;;
-    esac
+  case $mpiName in
+    openmpi | mpich )
+      export MPI_CC=${MPI_CC:-"mpicc"}
+      export MPI_CXX=${MPI_CXX:-"mpicxx"}
+      export MPI_FC=${MPI_FC:-"mpifort"}
+      ;;
+    impi )
+      export MPI_CC=${MPI_CC:-"mpiicc"}
+      export MPI_CXX=${MPI_CXX:-"mpiicpc"}
+      export MPI_FC=${MPI_FC:-"mpiifort"}
+      ;;
+    cray | cray* )
+      export MPI_CC=${MPI_CC:-"cc"}
+      export MPI_CXX=${MPI_CXX:-"CC"}
+      export MPI_FC=${MPI_FC:-"ftn"}
+      ;;
+    * )
+      echo "Unknown MPI option = $mpiName, ABORT!"
+      exit 1
+      ;;
+  esac
 
-    echo "=========================="
-    echo "MPI C Compiler: $MPI_CC"
-    echo "MPI C++ Compiler: $MPI_CXX"
-    echo "MPI Fortran Compiler: $MPI_FC"
-    echo "=========================="
-
+  echo "=========================="
+  echo "MPI C Compiler: $MPI_CC"
+  echo "MPI C++ Compiler: $MPI_CXX"
+  echo "MPI Fortran Compiler: $MPI_FC"
+  echo "=========================="
 }
 
 function set_pkg_root() {
   # export <PKG>_ROOT environment variables
+  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
   for i in $(printenv | grep "STACK_.*_build="); do
     pkg=$(echo $i | cut -d= -f1 | tr 'a-z' 'A-Z' | cut -d_ -f2- | rev | cut -d_ -f2- | rev)
     build=$(echo $i | cut -d= -f2)
     if [[ $build =~ ^(yes|YES|true|TRUE)$ ]]; then
-        eval export ${pkg}_ROOT=${PREFIX:-"/usr/local"}
+      eval export ${pkg}_ROOT=$prefix
     fi
   done
 }
 
 function build_lib() {
-    # Args: build_script_name
-    set +x
-    var="STACK_${1}_build"
-    set +u
-    stack_build=${!var}
-    set -u
-    if [[ ${stack_build} =~ [yYtT] ]]; then
-        [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
-        ${HPC_STACK_ROOT}/libs/build_$1.sh 2>&1 | tee "$logdir/$1.log"
-        ret=${PIPESTATUS[0]}
-        if [[ $ret > 0 ]]; then
-            echo "BUILD FAIL!  Lib: $1 Error:$ret"
-            [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
-        fi
-        echo "BUILD SUCCESS! Lib: $1"
-    fi
-    set -x
+  # Args: build_script_name
+  set +x
+  var="STACK_${1}_build"
+  set +u
+  stack_build=${!var}
+  set -u
+  if [[ ${stack_build} =~ [yYtT] ]]; then
+      [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
+      ${HPC_STACK_ROOT}/libs/build_$1.sh 2>&1 | tee "$logdir/$1.log"
+      ret=${PIPESTATUS[0]}
+      if [[ $ret > 0 ]]; then
+          echo "BUILD FAIL!  Lib: $1 Error:$ret"
+          [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
+      fi
+      echo "BUILD SUCCESS! Lib: $1"
+  fi
+  set -x
 }
 
 function build_nceplib() {
-    # Args: lib name
-    set +x
-    var="STACK_${1}_build"
-    set +u
-    stack_build=${!var}
-    set -u
-    if [[ ${stack_build} =~ [yYtT] ]]; then
-        [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
-        ${HPC_STACK_ROOT}/libs/build_nceplibs.sh "$1" 2>&1 | tee "$logdir/$1.log"
-        ret=${PIPESTATUS[0]}
-        if [[ $ret > 0 ]]; then
-            echo "BUILD FAIL!  NCEPlib: $1 Error:$ret"
-            [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
-        fi
-        echo "BUILD SUCCESS! NCEPlib: $1"
-    fi
-    set -x
+  # Args: lib name
+  set +x
+  var="STACK_${1}_build"
+  set +u
+  stack_build=${!var}
+  set -u
+  if [[ ${stack_build} =~ [yYtT] ]]; then
+      [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
+      ${HPC_STACK_ROOT}/libs/build_nceplibs.sh "$1" 2>&1 | tee "$logdir/$1.log"
+      ret=${PIPESTATUS[0]}
+      if [[ $ret > 0 ]]; then
+          echo "BUILD FAIL!  NCEPlib: $1 Error:$ret"
+          [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
+      fi
+      echo "BUILD SUCCESS! NCEPlib: $1"
+  fi
+  set -x
 }
 
 function parse_yaml {
   set +x
-  local prefix=$2
+  local yamlprefix=$2
   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
   sed -ne "s|^\($s\):|\1|" \
        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
@@ -157,7 +175,7 @@ function parse_yaml {
      for (i in vname) {if (i > indent) {delete vname[i]}}
      if (length($3) > 0) {
         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-        printf("export %s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+        printf("export %s%s%s=\"%s\"\n", "'$yamlprefix'",vn, $2, $3);
      }
   }'
   set -x

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -124,12 +124,10 @@ function set_pkg_root() {
 
 function set_no_modules_path() {
   # add $PREFIX to PATH, LD_LIBRARY_PATH and CMAKE_PREFIX_PATH
-  set +u
   prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
-  export PATH="$prefix/bin:${PATH:-}"
+  export PATH=$prefix/bin${PATH:+:$PATH}
   export LD_LIBRARY_PATH=$prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-  #export CMAKE_PREFIX_PATH=$prefix
-  set -u
+  export CMAKE_PREFIX_PATH=$prefix${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}
 }
 
 function build_lib() {

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -127,7 +127,7 @@ function set_no_modules_path() {
   prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
   export PATH="$prefix/bin:$PATH"
   export LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH"
-  export CMAKE_PREFIX_PATH=$prefix
+  #export CMAKE_PREFIX_PATH=$prefix
 }
 
 function build_lib() {


### PR DESCRIPTION
This PR:
- fixes an issue with `PATH`, `LD_LIBRARY_PATH` when `no_modules` are used.
- adds MKL modulefile
- cleans up `stack_helpers.sh` to make sure the variables are local
- adds `cray|cray*` section to `no_modules` to set `CC`, `FC` and `CXX`
- mpich does not depend on szip, remove it.
