### PR TITLE
Remove SUDO from hpc-stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ The first step is to chose the **COMPILER** and the **MPI** specify any other as
 
 - **HPC_MPI:** is the MPI library you wish to use for this build.  The format is the same as for `HPC_COMPILER`, for example: `HPC_MPI=impi/2020`.
 
-- **USE_SUDO:** If `PREFIX` is set to a value that requires root permission to write to, such as `/opt/modules`, then this flag should be enabled. For example, `USE_SUDO=Y`
-
 - **DOWNLOAD_ONLY:** The stack allows the option to download the source code for all the software without performing the installation.  This is especially useful for installing the stack on machines that do not allow internet connectivity to websites hosting the softwares e.g. GitHub.
 
 _**NOTE: To enable a boolean flag use a single-digit `Y` or `T`.  To disable, use `N` or `F` (case insensitive)**_

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -91,9 +91,6 @@ mpiVersion=$(echo $HPC_MPI | cut -d/ -f2)
 echo "Compiler: $compilerName/$compilerVersion"
 echo "MPI: $mpiName/$mpiVersion"
 
-# install with root permissions?
-[[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || export SUDO=""
-
 # ==============================================================================
 
 # create build directory if needed
@@ -181,7 +178,7 @@ build_nceplib grib_util
 # ==============================================================================
 # optionally clean up
 [[ $MAKE_CLEAN =~ [yYtT] ]] && \
-    ( $SUDO rm -rf $pkgdir; $SUDO rm -rf $logdir )
+    ( rm -rf $pkgdir; rm -rf $logdir )
 
 # ==============================================================================
 echo "build_stack.sh: SUCCESS!"

--- a/config/config_custom.sh
+++ b/config/config_custom.sh
@@ -5,7 +5,6 @@ export HPC_COMPILER=${HPC_COMPILER:-"gnu/9.3.0"}
 export HPC_MPI=${HPC_MPI:-"openmpi/4.0.1"}
 
 # Build options
-export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N

--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -5,7 +5,6 @@ export HPC_COMPILER="intel/18.0.5.274"
 export HPC_MPI="impi/2018.0.4"
 
 # Build options
-export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N

--- a/config/config_mac.sh
+++ b/config/config_mac.sh
@@ -5,7 +5,6 @@ export HPC_COMPILER="clang/11.0.3"
 export HPC_MPI="mpich/3.3.1"
 
 # Build options
-export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N

--- a/config/config_orion.sh
+++ b/config/config_orion.sh
@@ -11,7 +11,6 @@ export HPC_MPI="impi/2020"
 #export HPC_MPI="openmpi/4.0.2"
 
 # Build options
-export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N

--- a/config/config_wcoss_dell_p3.sh
+++ b/config/config_wcoss_dell_p3.sh
@@ -5,7 +5,6 @@ export HPC_COMPILER="ips/18.0.1.163"
 export HPC_MPI="impi/18.0.1"
 
 # Build options
-export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N

--- a/libs/build_boost.sh
+++ b/libs/build_boost.sh
@@ -18,16 +18,16 @@ url="https://dl.bintray.com/boostorg/release/$version/source/$software.tar.gz"
 
 if [[ $level = "headers-only" ]]; then
 
-    $MODULES && prefix="${PREFIX:-"/opt/modules"}/core/$name/$version" \
-             || prefix=${BOOST_ROOT:-"/usr/local"}
-    $SUDO mkdir -p $prefix $prefix/include
-    $SUDO cp -R boost $prefix/include
+  $MODULES && prefix="${PREFIX:-"/opt/modules"}/core/$name/$version" \
+           || prefix=${BOOST_ROOT:-"/usr/local"}
+  mkdir -p $prefix $prefix/include
+  cp -R boost $prefix/include
 
-    # generate modulefile from template
-    $MODULES && update_modules core "boost-headers" $version \
-             || echo "boost-headers" $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+  # generate modulefile from template
+  $MODULES && update_modules core "boost-headers" $version \
+           || echo "boost-headers" $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
 
-    exit 0
+  exit 0
 fi
 
 ########################################################################
@@ -39,19 +39,19 @@ mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 debug="--debug-configuration"
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    [[ -z $mpi ]] || module load hpc-$HPC_MPI
-    module list
-    set -x
-    prefix="${PREFIX:-"$HOME/opt"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-      [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  [[ -z $mpi ]] || module load hpc-$HPC_MPI
+  module list
+  set -x
+  prefix="${PREFIX:-"$HOME/opt"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${BOOST_ROOT:-"/usr/local"}
+  prefix=${BOOST_ROOT:-"/usr/local"}
 fi
 
 BoostRoot=$(pwd)
@@ -89,9 +89,9 @@ export PATH="$BoostBuild/bin:$PATH"
 
 cd $BoostRoot
 b2 $debug --build-dir=$build_boost address-model=64 toolset=$toolset stage
-$SUDO mkdir -p $prefix $prefix/include
-$SUDO cp -R boost $prefix/include
-$SUDO mv stage/lib $prefix
+mkdir -p $prefix $prefix/include
+cp -R boost $prefix/include
+mv stage/lib $prefix
 
 rm -f $HOME/user-config.jam
 

--- a/libs/build_cgal.sh
+++ b/libs/build_cgal.sh
@@ -23,26 +23,23 @@ set -eux
 name="cgal"
 version=${1:-${STACK_cgal_version}}
 
-[[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
-
-# this is only needed if MAKE_CHECK is enabled
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load boost-headers
-    module load zlib
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load boost-headers
+  module load zlib
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 
 else
-    prefix=${CGAL_ROOT:-"/usr/local"}
+  prefix=${CGAL_ROOT:-"/usr/local"}
 fi
 
 cd $HPC_STACK_ROOT/${PKGDIR:-"pkg"}
@@ -54,10 +51,8 @@ url="https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/$so
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 cmake . -DCMAKE_INSTALL_PREFIX=$prefix
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \
-   || echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_cmake.sh
+++ b/libs/build_cmake.sh
@@ -11,16 +11,16 @@ name="cmake"
 version=${1:-${STACK_cmake_version}}
 
 if $MODULES; then
-    module load hpc-$HPC_COMPILER
-    module list
+  module load hpc-$HPC_COMPILER
+  module list
 
-    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${CMAKE_ROOT:-"/usr/local"}
+  prefix=${CMAKE_ROOT:-"/usr/local"}
 fi
 
 software=$name-$version
@@ -34,9 +34,9 @@ export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 export FC=$SERIAL_FC
 
-$SUDO ./bootstrap --prefix=$prefix
-$SUDO make -j${NTHREADS:-4}
-$SUDO make install
+./bootstrap --prefix=$prefix
+make -j${NTHREADS:-4}
+make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \

--- a/libs/build_eigen.sh
+++ b/libs/build_eigen.sh
@@ -5,25 +5,21 @@ set -eux
 name="eigen"
 version=${1:-${STACK_eigen_version}}
 
-[[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
-
-# this is only needed if MAKE_CHECK is enabled
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load boost-headers
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load boost-headers
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${EIGEN_ROOT:-"/usr/local"}
+   prefix=${EIGEN_ROOT:-"/usr/local"}
 fi
 
 cd $HPC_STACK_ROOT/${PKGDIR:-"pkg"}
@@ -38,7 +34,7 @@ mkdir -p build && cd build
 
 cmake .. -DCMAKE_INSTALL_PREFIX=$prefix
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -39,10 +39,9 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version_install"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
-
 else
   prefix=${ESMF_ROOT:-"/usr/local"}
 fi
@@ -143,7 +142,7 @@ export ESMF_INSTALL_HEADERDIR=include
 
 make info
 make -j${NTHREADS:-4}
-$SUDO make install
+make install
 [[ $MAKE_CHECK =~ [yYtT] ]] && make installcheck
 
 # generate modulefile from template

--- a/libs/build_fftw.sh
+++ b/libs/build_fftw.sh
@@ -20,8 +20,8 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-      [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
   prefix=${FFTW_ROOT:-"/usr/local"}
@@ -38,8 +38,8 @@ else
 fi
 
 export F77=$FC
-export FFLAGS="${STACK_FFLAGS:-} ${STACK_fftw_FFLAGS} -fPIC"
-export CFLAGS="${STACK_CFLAGS:-} ${STACK_fftw_CFLAGS} -fPIC"
+export FFLAGS="${STACK_FFLAGS:-} ${STACK_fftw_FFLAGS:-} -fPIC"
+export CFLAGS="${STACK_CFLAGS:-} ${STACK_fftw_CFLAGS:-} -fPIC"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
@@ -56,7 +56,7 @@ mkdir -p build && cd build
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_gnu.sh
+++ b/libs/build_gnu.sh
@@ -18,7 +18,7 @@ contrib/download_prerequisites
 if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
                                || ( echo "ERROR: $prefix EXISTS, ABORT!"; exit 1 )
   fi
 else
@@ -36,7 +36,7 @@ extra_conf="--disable-multilib"
              --enable-languages=c,c++,fortran $extra_conf
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
-$SUDO make install-strip
+make install-strip
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \

--- a/libs/build_gptl.sh
+++ b/libs/build_gptl.sh
@@ -10,21 +10,21 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_MPI
-    module try-load cmake
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module try-load cmake
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir -p $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${GPTL_ROOT:-"/usr/local"}
+  prefix=${GPTL_ROOT:-"/usr/local"}
 fi
 
 export FC=$MPI_FC
@@ -43,7 +43,7 @@ mkdir -p build && cd build
 ../configure --enable-pmpi --prefix=$prefix
 VERBOSE=$MAKE_VERBOSE make
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-VERBOSE=$MAKE_VERBOSE $SUDO make install
+VERBOSE=$MAKE_VERBOSE make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -25,10 +25,9 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
-
 else
     prefix=${HDF5_ROOT:-"/usr/local"}
 fi
@@ -72,8 +71,7 @@ mkdir -p build && cd build
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-[[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
-                          || make install
+make install
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -18,11 +18,11 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-      [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
-    prefix=${JASPER_ROOT:-"/usr/local"}
+  prefix=${JASPER_ROOT:-"/usr/local"}
 fi
 
 export FC=$SERIAL_FC
@@ -71,7 +71,7 @@ fi
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -10,20 +10,19 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${JPEG_ROOT:-"/usr/local"}
+  prefix=${JPEG_ROOT:-"/usr/local"}
 fi
 
 export CC=$SERIAL_CC
@@ -49,7 +48,7 @@ cmake $sourceDir \
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_lapack.sh
+++ b/libs/build_lapack.sh
@@ -10,20 +10,19 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${LAPACK_ROOT:-"/usr/local"}
+  prefix=${LAPACK_ROOT:-"/usr/local"}
 fi
 
 export FC=$SERIAL_FC
@@ -51,7 +50,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_
 
 VERBOSE="$MAKE_VERBOSE" make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-VERBOSE="$MAKE_VERBOSE" $SUDO make install
+VERBOSE="$MAKE_VERBOSE" make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_mpi.sh
+++ b/libs/build_mpi.sh
@@ -32,7 +32,7 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
                                || ( echo "ERROR: $prefix EXISTS, ABORT!"; exit 1 )
   fi
 else
@@ -83,7 +83,7 @@ esac
 ../configure --prefix=$prefix $extra_conf
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_nccmp.sh
+++ b/libs/build_nccmp.sh
@@ -18,38 +18,38 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    [[ -z $mpi ]] || module load hpc-$HPC_MPI
-    module try-load szip
-    module load hdf5
-    module load netcdf
-    module list
-    set -x
-    enable_pnetcdf=$(nc-config --has-pnetcdf)
-    set +x
-      [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  [[ -z $mpi ]] || module load hpc-$HPC_MPI
+  module try-load szip
+  module load hdf5
+  module load netcdf
+  module list
+  set -x
+  enable_pnetcdf=$(nc-config --has-pnetcdf)
+  set +x
+    [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${NCCMP_ROOT:-"/usr/local"}
-    enable_pnetcdf=$(nc-config --has-pnetcdf)
+  prefix=${NCCMP_ROOT:-"/usr/local"}
+  enable_pnetcdf=$(nc-config --has-pnetcdf)
 fi
 
 if [[ ! -z $mpi ]]; then
-    export FC=$MPI_FC
-    export CC=$MPI_CC
-    export CXX=$MPI_CXX
+  export FC=$MPI_FC
+  export CC=$MPI_CC
+  export CXX=$MPI_CXX
 else
-    export FC=$SERIAL_FC
-    export CC=$SERIAL_CC
-    export CXX=$SERIAL_CXX
+  export FC=$SERIAL_FC
+  export CC=$SERIAL_CC
+  export CXX=$SERIAL_CXX
 fi
 
 export CFLAGS="${STACK_CFLAGS:-} ${STACK_nccmp_CFLAGS:-} -fPIC"
@@ -83,7 +83,7 @@ cmake .. \
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -114,7 +114,7 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 
@@ -185,8 +185,7 @@ cmake .. \
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-[[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
-                          || make install
+make install
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -29,7 +29,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
 
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
@@ -38,13 +38,13 @@ else
 fi
 
 if [[ ! -z $mpi ]]; then
-    export FC=$MPI_FC
-    export CC=$MPI_CC
-    export CXX=$MPI_CXX
+  export FC=$MPI_FC
+  export CC=$MPI_CC
+  export CXX=$MPI_CXX
 else
-    export FC=$SERIAL_FC
-    export CC=$SERIAL_CC
-    export CXX=$SERIAL_CXX
+  export FC=$SERIAL_FC
+  export CC=$SERIAL_CC
+  export CXX=$SERIAL_CXX
 fi
 
 export FFLAGS="${STACK_FFLAGS:-} ${STACK_nco_FFLAGS:-} -fPIC"
@@ -92,7 +92,7 @@ cmake .. \
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -14,36 +14,35 @@ mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 [[ ${STACK_netcdf_enable_pnetcdf:-} =~ [yYtT] ]] && enable_pnetcdf=YES || enable_pnetcdf=NO
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    [[ -z $mpi ]] || module load hpc-$HPC_MPI
-    module try-load szip
-    module load hdf5
-    if [[ ! -z $mpi ]]; then
-      [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
-    fi
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  [[ -z $mpi ]] || module load hpc-$HPC_MPI
+  module try-load szip
+  module load hdf5
+  if [[ ! -z $mpi ]]; then
+    [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
+  fi
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$c_version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$c_version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${NETCDF_ROOT:-"/usr/local"}
+  prefix=${NETCDF_ROOT:-"/usr/local"}
 fi
 
 if [[ ! -z $mpi ]]; then
-    export FC=$MPI_FC
-    export CC=$MPI_CC
-    export CXX=$MPI_CXX
+  export FC=$MPI_FC
+  export CC=$MPI_CC
+  export CXX=$MPI_CXX
 else
-    export FC=$SERIAL_FC
-    export CC=$SERIAL_CC
-    export CXX=$SERIAL_CXX
+  export FC=$SERIAL_FC
+  export CC=$SERIAL_CC
+  export CXX=$SERIAL_CXX
 fi
 
 export F77=$FC
@@ -122,7 +121,7 @@ mkdir -p build && cd build
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 $MODULES || echo $software >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
 
@@ -172,7 +171,7 @@ mkdir -p build && cd build
 #VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE make -j1 #NetCDF-Fortran-4.5.2 & intel/20 have a linker bug if built with j>1
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 cd $curr_dir
 
@@ -196,6 +195,6 @@ mkdir -p build && cd build
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 $MODULES || echo $software >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -13,25 +13,25 @@ mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 [[ ${STACK_pio_enable_gptl:-} =~ [yYtT] ]] && enable_gptl=YES || enable_gptl=NO
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_MPI
-    module try-load cmake
-    module load szip
-    module load hdf5
-    [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
-    module load netcdf
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module try-load cmake
+  module load szip
+  module load hdf5
+  [[ $enable_pnetcdf =~ [yYtT] ]] && module load pnetcdf
+  module load netcdf
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${PIO_ROOT:-"/usr/local"}
+  prefix=${PIO_ROOT:-"/usr/local"}
 fi
 
 export FC=$MPI_FC
@@ -77,7 +77,7 @@ cmake ..\
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-VERBOSE=$MAKE_VERBOSE $SUDO make install
+VERBOSE=$MAKE_VERBOSE make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \

--- a/libs/build_pnetcdf.sh
+++ b/libs/build_pnetcdf.sh
@@ -10,20 +10,20 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_MPI
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${PNETCDF_ROOT:-"/usr/local"}
+  prefix=${PNETCDF_ROOT:-"/usr/local"}
 fi
 
 export FC=$MPI_FC
@@ -53,7 +53,7 @@ mkdir -p build && cd build
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -12,21 +12,20 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load zlib
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load zlib
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${PNG_ROOT:-"/usr/local"}
+  prefix=${PNG_ROOT:-"/usr/local"}
 fi
 
 export CC=$SERIAL_CC
@@ -53,7 +52,7 @@ cmake $sourceDir \
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_szip.sh
+++ b/libs/build_szip.sh
@@ -12,20 +12,19 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
-
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${SZIP_ROOT:-"/usr/local"}
+  prefix=${SZIP_ROOT:-"/usr/local"}
 fi
 
 export CC=$SERIAL_CC
@@ -53,7 +52,7 @@ mkdir -p build && cd build
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_tau2.sh
+++ b/libs/build_tau2.sh
@@ -11,30 +11,30 @@ mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_MPI
-    module load pdtoolkit
-    module load zlib
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module load pdtoolkit
+  module load zlib
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${TAU_ROOT:-"/usr/local/$name/$version"}
+  prefix=${TAU_ROOT:-"/usr/local/$name/$version"}
 fi
 
 export CC=${MPI_CC:-"mpicc"}
 export CXX=${MPI_CXX:-"mpiicpc"}
 if [[ $MPI_FC = "mpifort" ]]; then
-    export FC="mpif90"
+  export FC="mpif90"
 else
-    export FC=${MPI_FC:-"mpif90"}
+  export FC=${MPI_FC:-"mpif90"}
 fi
 
 export PDTOOLKIT_ROOT=$PDT_ROOT
@@ -48,13 +48,13 @@ software=tau2
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 [[ -d build ]] && rm -rf build
 
-$SUDO ./configure -prefix=$prefix -c++=$CXX -cc=$CC -fortran=$FC -mpi -ompt -bfd=download \
-                  -dwarf=download -unwind=download -iowrapper -pdt=$PDTOOLKIT_ROOT
+./configure -prefix=$prefix -c++=$CXX -cc=$CC -fortran=$FC -mpi -ompt -bfd=download \
+            -dwarf=download -unwind=download -iowrapper -pdt=$PDTOOLKIT_ROOT
 
 #                  -arch=x86_64
 
 # Note - if this doesn't work you might have to run the entire script as root
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \

--- a/libs/build_tkdiff.sh
+++ b/libs/build_tkdiff.sh
@@ -9,13 +9,13 @@ name="tkdiff"
 version=${1:-${STACK_tkdiff_version}}
 
 if $MODULES; then
-    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix; mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${TKDIFF_ROOT:-"/usr/local"}
+  prefix=${TKDIFF_ROOT:-"/usr/local"}
 fi
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
@@ -24,8 +24,8 @@ software=tkdiff-$(echo $version | sed 's/\./-/g')
 url="https://sourceforge.net/projects/tkdiff/files/tkdiff/$version/$software.zip"
 [[ -d $software ]] || ($WGET $url; unzip $software.zip)
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
-$SUDO mkdir -p $prefix/bin
-$SUDO mv $software/tkdiff $prefix/bin
+mkdir -p $prefix/bin
+mv $software/tkdiff $prefix/bin
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -11,19 +11,19 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 [[ ${STACK_udunits_shared:-} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module list
-    set -x
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${UDUNITS_ROOT:-"/usr/local"}
+  prefix=${UDUNITS_ROOT:-"/usr/local"}
 fi
 
 export FC=$SERIAL_FC
@@ -50,7 +50,7 @@ mkdir -p build && cd build
 
 make -j${NTHREADS:-4}
 [[ "$MAKE_CHECK" = "YES" ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/libs/build_zlib.sh
+++ b/libs/build_zlib.sh
@@ -11,18 +11,18 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 [[ ${STACK_zlib_shared:-} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
 
 if $MODULES; then
-    set +x
-    source $MODULESHOME/init/bash
-    module load hpc-$HPC_COMPILER
-    module list
-    set -x
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
-    if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${ZLIB_ROOT:-"/usr/local"}
+  prefix=${ZLIB_ROOT:-"/usr/local"}
 fi
 
 export FC=$SERIAL_FC
@@ -57,7 +57,7 @@ fi
 
 make -j${NTHREADS:-4}
 [[ "$MAKE_CHECK" = "YES" ]] && make check
-$SUDO make install
+make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \

--- a/setup_modules.sh
+++ b/setup_modules.sh
@@ -78,23 +78,20 @@ mpiVersion=$(echo $HPC_MPI | cut -d/ -f2)
 echo "Compiler: $compilerName/$compilerVersion"
 echo "MPI: $mpiName/$mpiVersion"
 
-# install with root permissions?
-[[ $USE_SUDO =~ [yYtT] ]] && SUDO="sudo" || SUDO=""
-
 #===============================================================================
 # Deploy directory structure for modulefiles
 
-$SUDO mkdir -p $PREFIX/modulefiles/core
-$SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion
-$SUDO mkdir -p $PREFIX/modulefiles/mpi/$compilerName/$compilerVersion/$mpiName/$mpiVersion
+mkdir -p $PREFIX/modulefiles/core
+mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion
+mkdir -p $PREFIX/modulefiles/mpi/$compilerName/$compilerVersion/$mpiName/$mpiVersion
 
-$SUDO mkdir -p $PREFIX/modulefiles/core/hpc-$compilerName
-$SUDO cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
-         $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
+mkdir -p $PREFIX/modulefiles/core/hpc-$compilerName
+cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
+   $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
 
-$SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
-$SUDO cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
-         $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
+mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
+cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
+   $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
 
 #===============================================================================
 # Query the user if using native compiler and MPI
@@ -103,8 +100,9 @@ read responseCompiler
 if [[ $responseCompiler =~ [yYtT] ]]; then
   echo -e "==========================\n USING NATIVE COMPILER"
   cd $PREFIX/modulefiles/core/hpc-$compilerName
-  $SUDO sed -i -e '/load(compiler)/d' $compilerVersion.lua
-  $SUDO sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
+  sed -i -e '/load(compiler)/d' $compilerVersion.lua
+  sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
+  [[ -f $compilerVersion.lua-e ]] && rm -f "$compilerVersion.lua-e" # Stupid macOS does not understand -i, and creates a backup with -e (-e is the next sed option)
   echo
 fi
 
@@ -113,23 +111,25 @@ read responseMPI
 if [[ $responseMPI =~ [yYtT] ]]; then
   echo -e "===========================\n USING NATIVE MPI"
   cd $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
-  $SUDO sed -i -e '/load(mpi)/d' $mpiVersion.lua
-  $SUDO sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
+  sed -i -e '/load(mpi)/d' $mpiVersion.lua
+  sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
+  [[ -f $mpiVersion.lua-e ]] && rm -f "$mpiVersion.lua-e"
   echo
 fi
 
 #===============================================================================
 
 # Deploy directory for stack modulefile
-$SUDO mkdir -p $PREFIX/modulefiles/stack/hpc
-$SUDO cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
-         $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+mkdir -p $PREFIX/modulefiles/stack/hpc
+cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
+   $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
 
 # Replace #PREFIX# from template with $PREFIX,
 # sed does not like delimiter (/) to be a part of replacement string, do magic!
 cd $PREFIX/modulefiles/stack/hpc
 repl=$(echo ${PREFIX} | sed -e "s#/#\\\/#g")
-$SUDO sed -i -e "s/#HPC_OPT#/${repl}/g" $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+sed -i -e "s/#HPC_OPT#/${repl}/g" $HPC_STACK_VERSION.lua
+[[ -f $HPC_STACK_VERSION.lua-e ]] && rm -f "$HPC_STACK_VERSION.lua-e"
 
 #===============================================================================
 

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -28,12 +28,12 @@ function update_modules {
   [[ -d $to_dir ]] || ( echo "ERROR: $mod_dir MODULE DIRECTORY NOT FOUND! ABORT!"; exit 1 )
 
   cd $to_dir
-  $SUDO mkdir -p $name; cd $name
-  $SUDO cp $tmpl_file $version.lua
+  mkdir -p $name; cd $name
+  cp $tmpl_file $version.lua
 
   # Make the latest installed version the default
-  [[ -e default ]] && $SUDO rm -f default
-  $SUDO ln -s $version.lua default
+  [[ -e default ]] && rm -f default
+  ln -s $version.lua default
 }
 
 function no_modules {


### PR DESCRIPTION
This PR:
- removes the `USE_SUDO` option from config files.
- removes `$SUDO` from all the build scripts.
- removes the `USE_SUDO` description from `README.md` file.

If installation into a system location is required, this can be achieved by executing `sudo` on the driver scripts `setup_modules.sh` or `build_stack.sh` themselves.