### PR TITLE
add FMS to hpc-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The following software can optionally be built with the scripts under `libs`. Th
 
 * UFS Dependencies
   - [ESMF](https://www.earthsystemcog.org/projects/esmf/)
+  - [FMS](https://github.com/noaa-gfdl/fms.git)
 
 * NCEP Libraries
   - [NCEPLIBS-bacio](https://github.com/noaa-emc/nceplibs-bacio.git)

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -152,6 +152,7 @@ build_lib pio
 # UFS 3rd party dependencies
 
 build_lib esmf
+build_lib fms
 
 # NCEPlibs
 

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -76,6 +76,12 @@ esmf:
   enable_pnetcdf: NO
   debug: NO
 
+fms:
+  build: YES
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
 bacio:
   build: YES
   version: v2.4.1

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -77,7 +77,7 @@ esmf:
   debug: NO
 
 fms:
-  build: YES
+  build: NO
   version: master
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -76,6 +76,12 @@ esmf:
   enable_pnetcdf: NO
   debug: NO
 
+fms:
+  build: YES
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
 bacio:
   build: YES
   version: v2.4.1

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -77,7 +77,7 @@ esmf:
   debug: NO
 
 fms:
-  build: YES
+  build: NO
   version: master
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -72,6 +72,12 @@ esmf:
   enable_pnetcdf: NO
   debug: NO
 
+fms:
+  build: NO
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
 bacio:
   build: YES
   version: v2.4.1

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eux
+
+name="fms"
+repo=${1:-${STACK_fms_repo:-"noaa-gfdl"}}
+version=${2:-${STACK_fms_version:-"master"}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+mpi=$(echo $HPC_MPI | sed 's/\//-/g')
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module try-load cmake
+  module load netcdf
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${FMS_ROOT:-"/usr/local"}
+fi
+
+export FC=$MPI_FC
+export CC=$MPI_CC
+
+export CFLAGS="${STACK_CFLAGS:-} ${STACK_fms_CFLAGS:-} -fPIC -w"
+export FFLAGS="${STACK_FFLAGS:-} ${STACK_fms_FFLAGS:-} -fPIC -w"
+export FCFLAGS="${FFLAGS}"
+
+software=$name-$repo-$version
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+[[ -d $software ]] || git clone https://github.com/$repo/$name.git $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+
+CMAKE_OPTS=${STACK_fms_cmake_opts:-""}
+
+cmake .. \
+      -DCMAKE_INSTALL_PREFIX=$prefix \
+      -D32BIT=ON -D64BIT=ON ${CMAKE_OPTS}
+
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
+#[[ $MAKE_CHECK =~ [yYtT] ]] && make check # make check is not implemented in cmake builds
+VERBOSE=$MAKE_VERBOSE $SUDO make install
+
+# generate modulefile from template
+$MODULES && update_modules mpi $name $repo-$version \
+         || echo $name $repo-$version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fms/fms.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fms/fms.lua
@@ -1,0 +1,26 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+setenv("FMS_ROOT", base)
+setenv("FMS_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: GFDL FMS library")


### PR DESCRIPTION
This PR:
- adds the capability to build FMS as part of the hpc-stack.
- It is default `OFF` for NOAA machines in `stack_noaa.yaml`.
- A modulefile is also created and FMS module can be loaded via `module load fms`.  The modulefile sets the environment variable `FMS_ROOT`