### PR TITLE
bugfix in stack_helpers.sh

### DIFF
--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -202,7 +202,7 @@ eigen:
   version: 3.3.7
 
 gsl_lite:
-  build: YES
+  build: NO
   version: 0.37.0
 
 gptl:

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -144,6 +144,7 @@ set -x
 # Load netcdf-c before building netcdf-fortran
 set +x
 $MODULES && module load netcdf
+$MODULES && module list
 set -x
 
 if [[ ${STACK_netcdf_shared} =~ [yYtT] ]]; then
@@ -156,7 +157,6 @@ fi
 export CFLAGS+=" -I$prefix/include"
 export CXXFLAGS+=" -I$prefix/include"
 
-echo $LDFLAGS
 cd $curr_dir
 
 version=$f_version

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
 function update_modules {
-  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
-  modpath=$1
-  name=$2
-  version=$3
+  local prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
+  local modpath=$1
+  local name=$2
+  local version=$3
   case $modpath in
     core )
-      tmpl_file=$HPC_STACK_ROOT/modulefiles/core/$name/$name.lua
-      to_dir=$prefix/modulefiles/core
+      local tmpl_file=$HPC_STACK_ROOT/modulefiles/core/$name/$name.lua
+      local to_dir=$prefix/modulefiles/core
       ;;
     compiler )
-      tmpl_file=$HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/$name/$name.lua
-      to_dir=$prefix/modulefiles/compiler/$HPC_COMPILER
+      local tmpl_file=$HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/$name/$name.lua
+      local to_dir=$prefix/modulefiles/compiler/$HPC_COMPILER
       ;;
     mpi )
-      tmpl_file=$HPC_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$name/$name.lua
-      to_dir=$prefix/modulefiles/mpi/$HPC_COMPILER/$HPC_MPI
+      local tmpl_file=$HPC_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$name/$name.lua
+      local to_dir=$prefix/modulefiles/mpi/$HPC_COMPILER/$HPC_MPI
       ;;
     * )
       echo "ERROR: INVALID MODULE PATH, ABORT!"
@@ -42,8 +42,8 @@ function no_modules {
   # normally done by the modules.
   # It's mainly intended for use when not using LMod
 
-  compilerName=$(echo $HPC_COMPILER | cut -d/ -f1)
-  mpiName=$(echo $HPC_MPI | cut -d/ -f1)
+  local compilerName=$(echo $HPC_COMPILER | cut -d/ -f1)
+  local mpiName=$(echo $HPC_MPI | cut -d/ -f1)
 
   # these can be specified in the config file
   # so these should be considered defaults
@@ -112,10 +112,10 @@ function no_modules {
 
 function set_pkg_root() {
   # export <PKG>_ROOT environment variables
-  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
+  local prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
   for i in $(printenv | grep "STACK_.*_build="); do
-    pkg=$(echo $i | cut -d= -f1 | tr 'a-z' 'A-Z' | cut -d_ -f2- | rev | cut -d_ -f2- | rev)
-    build=$(echo $i | cut -d= -f2)
+    local pkg=$(echo $i | cut -d= -f1 | tr 'a-z' 'A-Z' | cut -d_ -f2- | rev | cut -d_ -f2- | rev)
+    local build=$(echo $i | cut -d= -f2)
     if [[ $build =~ ^(yes|YES|true|TRUE)$ ]]; then
       eval export ${pkg}_ROOT=$prefix
     fi
@@ -124,7 +124,7 @@ function set_pkg_root() {
 
 function set_no_modules_path() {
   # add $PREFIX to PATH, LD_LIBRARY_PATH and CMAKE_PREFIX_PATH
-  prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
+  local prefix=${PREFIX:-${HPC_OPT:-"/usr/local"}}
   export PATH=$prefix/bin${PATH:+:$PATH}
   export LD_LIBRARY_PATH=$prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   export CMAKE_PREFIX_PATH=$prefix${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}
@@ -133,14 +133,14 @@ function set_no_modules_path() {
 function build_lib() {
   # Args: build_script_name
   set +x
-  var="STACK_${1}_build"
+  local var="STACK_${1}_build"
   set +u
-  stack_build=${!var}
+  local stack_build=${!var}
   set -u
   if [[ ${stack_build} =~ [yYtT] ]]; then
       [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
       ${HPC_STACK_ROOT}/libs/build_$1.sh 2>&1 | tee "$logdir/$1.log"
-      ret=${PIPESTATUS[0]}
+      local ret=${PIPESTATUS[0]}
       if [[ $ret > 0 ]]; then
           echo "BUILD FAIL!  Lib: $1 Error:$ret"
           [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
@@ -153,14 +153,14 @@ function build_lib() {
 function build_nceplib() {
   # Args: lib name
   set +x
-  var="STACK_${1}_build"
+  local var="STACK_${1}_build"
   set +u
-  stack_build=${!var}
+  local stack_build=${!var}
   set -u
   if [[ ${stack_build} =~ [yYtT] ]]; then
       [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
       ${HPC_STACK_ROOT}/libs/build_nceplibs.sh "$1" 2>&1 | tee "$logdir/$1.log"
-      ret=${PIPESTATUS[0]}
+      local ret=${PIPESTATUS[0]}
       if [[ $ret > 0 ]]; then
           echo "BUILD FAIL!  NCEPlib: $1 Error:$ret"
           [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret


### PR DESCRIPTION
This PR:
- declares variables in stack_helpers.sh functions as `local`. Otherwise they affect the sourcing script.
- disables gsl_lite on noaa platforms in `stack_noaa.yaml`