### PR TITLE
Update Jasper to fix 'dangerous use of mktemp'

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -29,7 +29,7 @@ szip:
 
 jasper:
   build: YES
-  version: 2.0.15
+  version: 2.0.22
 
 udunits:
   build: YES

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -29,7 +29,7 @@ szip:
 
 jasper:
   build: YES
-  version: 2.0.15
+  version: 2.0.22
 
 udunits:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -24,7 +24,7 @@ szip:
 jasper:
   build: YES
   shared: NO
-  version: 2.0.15
+  version: 2.0.22
 
 udunits:
   build: YES


### PR DESCRIPTION
Jasper was updated some security fixes, including one for this.

Tested with NCEPLIBS and the weather model

Fixes #30 