### PR TITLE
Build static libjpeg if requested, use hpc-stack libjpeg if built in jasper and NCEPLIBS; add NCAR Cheyenne

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="gnu/9.1.0"
+export HPC_MPI="mpt/2.22"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=Y
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+
+# Load these basic modules for Hera
+module load cmake/3.16.4

--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -17,5 +17,5 @@ export DOWNLOAD_ONLY=N
 export STACK_EXIT_ON_FAIL=Y
 export WGET="wget -nv"
 
-# Load these basic modules for Hera
+# Load these basic modules for Cheyenne
 module load cmake/3.16.4

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="intel/19.1.1"
+export HPC_MPI="mpt/2.22"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=Y
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+
+# Load these basic modules for Hera
+module load cmake/3.16.4

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -17,5 +17,5 @@ export DOWNLOAD_ONLY=N
 export STACK_EXIT_ON_FAIL=Y
 export WGET="wget -nv"
 
-# Load these basic modules for Hera
+# Load these basic modules for Cheyenne
 module load cmake/3.16.4

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -1,0 +1,243 @@
+cmake:
+  build: NO
+  version: 3.17.2
+
+jpeg:
+  build: YES
+  shared: NO
+  version: 9.1.0
+
+zlib:
+  build: YES
+  shared: NO
+  version: 1.2.11
+
+png:
+  build: YES
+  shared: NO
+  version: 1.6.35
+
+szip:
+  build: YES
+  shared: NO
+  version: 2.1.1
+
+jasper:
+  build: YES
+  shared: NO
+  version: 2.0.22
+
+udunits:
+  build: YES
+  shared: NO
+  version: 2.2.26
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: NO
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: NO
+
+netcdf:
+  build: YES
+  shared: NO
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.3
+  version_cxx: 4.3.1
+
+nccmp:
+  build: YES
+  version: 1.8.7.0
+
+nco:
+  build: NO
+  version: 4.9.3
+
+pio:
+  build: YES
+  version: 2.5.1
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: 8_1_0_beta_snapshot_27
+  shared: NO
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: NO
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+
+ip2:
+  build: NO
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+
+g2:
+  build: YES
+  version: v3.4.1
+  install_as: 3.4.1
+
+g2tmpl:
+  build: YES
+  version: v1.9.1
+  install_as: 1.9.1
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+
+nceppost:
+  build: YES
+  version: dceca26
+  install_as: dceca26
+  openmp: ON
+
+wrf_io:
+  build: YES
+  version: v1.1.1-cmake-v5
+  install_as: 1.1.1
+  openmp: ON
+
+bufr:
+  build: YES
+  version: bufr_v11.4.0
+  install_as: 11.4.0
+
+wgrib2:
+  build: YES
+  version: v2.0.8-cmake-v5
+  install_as: 2.0.8
+  openmp: OFF
+  spectral: OFF
+  ipolates: 0
+
+prod_util:
+  build: YES
+  version: v1.2.1
+  install_as: 1.2.1
+
+grib_util:
+  build: YES
+  version: v1.2.1
+  install_as: 1.2.1
+  openmp: ON
+
+boost:
+  build: YES
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: NO
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+ecbuild:
+  build: YES
+  version: release-stable
+  repo: jcsda
+
+eckit:
+  build: YES
+  version: release-stable
+  repo: jcsda
+
+fckit:
+  build: YES
+  version: release-stable
+  repo: jcsda
+
+atlas:
+  build: YES
+  version: release-stable
+  repo: jcsda

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -4,6 +4,7 @@ cmake:
 
 jpeg:
   build: NO
+  shared: NO
   version: 9.1.0
 
 zlib:

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -109,6 +109,10 @@ case $MPI in
   impi )
     export ESMF_COMM="intelmpi"
     ;;
+  mpt )
+    export ESMF_COMM="mpt"
+    export ESMF_MPIRUN=mpiexec_mpt
+    ;;
   * )
     export ESMF_COMM="mpiuni"
     export ESMF_MPIRUN=""

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -14,6 +14,9 @@ if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
   module load hpc-$HPC_COMPILER
+  # Load jpeg module if created by hpc-stack; requires setting
+  # MAKE_POLICY_DEFAULT_CMP0074 to new below so that JPEG_ROOT is searched
+  module try-load jpeg
   module list
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
@@ -55,10 +58,6 @@ if [ "$(printf '%s\n' "$cmakeVer" "$version" | sort -V | head -n1)" = "$cmakeVer
 else
     useCmake=NO
 fi
-
-# Load jpeg module if created by hpc-stack; requires setting
-# MAKE_POLICY_DEFAULT_CMP0074 to new below so that JPEG_ROOT is searched
-module try-load jpeg
 
 if [[ "$useCmake" == "YES" ]]; then
     cd $sourceDir

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -56,6 +56,10 @@ else
     useCmake=NO
 fi
 
+if [[ "${STACK_jpeg_build}" == "YES" ]]; then
+    module load jpeg
+fi
+
 if [[ "$useCmake" == "YES" ]]; then
     cd $sourceDir
     cmake -G "Unix Makefiles" \
@@ -63,6 +67,7 @@ if [[ "$useCmake" == "YES" ]]; then
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=RELEASE \
       -DJAS_ENABLE_DOC=FALSE \
+      -DCMAKE_POLICY_DEFAULT_CMP0074=NEW \
       $shared_flags
     cd $buildDir
 else

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -56,9 +56,9 @@ else
     useCmake=NO
 fi
 
-if [[ "${STACK_jpeg_build}" == "YES" ]]; then
-    module load jpeg
-fi
+# Load jpeg module if created by hpc-stack; requires setting
+# MAKE_POLICY_DEFAULT_CMP0074 to new below so that JPEG_ROOT is searched
+module try-load jpeg
 
 if [[ "$useCmake" == "YES" ]]; then
     cd $sourceDir

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -5,6 +5,8 @@ set -eux
 name="jpeg"
 version=${1:-${STACK_jpeg_version}}
 
+[[ ${STACK_jpeg_shared:-} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
+
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 
@@ -40,11 +42,14 @@ sourceDir=$PWD
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
+[[ $enable_shared =~ [yYtT] ]] && shared_flags="" || shared_flags="-DBUILD_STATIC=ON"
+
 cmake $sourceDir \
   -DCMAKE_INSTALL_PREFIX=$prefix \
   -DBUILD_TESTS=ON \
   -DBUILD_EXECUTABLES=ON \
-  -DCMAKE_BUILD_TYPE=RELEASE
+  -DCMAKE_BUILD_TYPE=RELEASE \
+  ${shared_flags}
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -43,13 +43,12 @@ sourceDir=$PWD
 mkdir -p build && cd build
 
 [[ $enable_shared =~ [yYtT] ]] && shared_flags="" || shared_flags="-DBUILD_STATIC=ON"
+[[ $MAKE_CHECK =~ [yYtT] ]] && check_flags="-DBUILD_TESTS=ON"
 
 cmake $sourceDir \
   -DCMAKE_INSTALL_PREFIX=$prefix \
-  -DBUILD_TESTS=ON \
   -DBUILD_EXECUTABLES=ON \
-  -DCMAKE_BUILD_TYPE=RELEASE \
-  ${shared_flags}
+  -DCMAKE_BUILD_TYPE=RELEASE ${shared_flags:-} ${check_flags:-}
 
 make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -38,6 +38,7 @@ if $MODULES; then
     wgrib2)
       mpi=$mpi_check
       [[ -z $mpi ]] || module load hpc-$HPC_MPI
+      module try-load jpeg
       module try-load jasper
       module try-load zlib
       module try-load png
@@ -49,6 +50,7 @@ if $MODULES; then
       module load sp
       ;;
     g2)
+      module try-load jpeg
       module try-load png
       module try-load jasper
       ;;
@@ -96,6 +98,7 @@ if $MODULES; then
       # module load nemsio
       ;;
     grib_util)
+      module try-load jpeg
       module try-load jasper
       module try-load zlib
       module try-load png


### PR DESCRIPTION
This PR fixes a few issues with libjpeg that surfaced when trying to install libjpeg on Cheyenne, see https://github.com/NOAA-EMC/hpc-stack/issues/39.

It also adds the configuration files for Cheyenne with Intel and GNU, and a separate NCAR YAML stack config. The latter differs from the NOAA config in building a static version of libjpeg.

Limitations:
- I fixed the jasper cmake build only, i.e. only for newer versions of jasper.
- The ufs-weather-model executable now launches, i.e. the library load problem is solved, but terminates immediately after the ESMF init. It also prints the ESMF banner ntasks number of times. I have seen this before, presumably ESMF is not built correctly on SGI MPI systems. I can fix this in this or a follow-up PR, whatever is better.