### PR TITLE
add UPP to hpc-stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.tgz
 *.bz2
 *.log*
+nohup*
 
 # Ignore the contents of these directories
 pkg*/

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -151,7 +151,7 @@ build_lib pio
 
 # UFS 3rd party dependencies
 
-#build_lib esmf
+build_lib esmf
 build_lib fms
 
 # NCEPlibs
@@ -182,22 +182,22 @@ build_nceplib grib_util
 
 # JEDI 3rd party dependencies
 
-#build_lib boost
-#build_lib eigen
-#build_lib gsl_lite
-#build_lib gptl
-#build_lib fftw
-#build_lib tau2
-#build_lib cgal
-#build_lib json
-#build_lib json_schema_validator
+build_lib boost
+build_lib eigen
+build_lib gsl_lite
+build_lib gptl
+build_lib fftw
+build_lib tau2
+build_lib cgal
+build_lib json
+build_lib json_schema_validator
 
 # JCSDA JEDI dependencies
 
-#build_lib ecbuild
-#build_lib eckit
-#build_lib fckit
-#build_lib atlas
+build_lib ecbuild
+build_lib eckit
+build_lib fckit
+build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -173,6 +173,7 @@ build_nceplib g2c
 build_nceplib g2tmpl
 build_nceplib crtm
 build_nceplib nceppost
+build_nceplib upp
 build_nceplib wrf_io
 build_nceplib bufr
 build_nceplib wgrib2

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -151,7 +151,7 @@ build_lib pio
 
 # UFS 3rd party dependencies
 
-build_lib esmf
+#build_lib esmf
 build_lib fms
 
 # NCEPlibs
@@ -182,22 +182,22 @@ build_nceplib grib_util
 
 # JEDI 3rd party dependencies
 
-build_lib boost
-build_lib eigen
-build_lib gsl_lite
-build_lib gptl
-build_lib fftw
-build_lib tau2
-build_lib cgal
-build_lib json
-build_lib json_schema_validator
+#build_lib boost
+#build_lib eigen
+#build_lib gsl_lite
+#build_lib gptl
+#build_lib fftw
+#build_lib tau2
+#build_lib cgal
+#build_lib json
+#build_lib json_schema_validator
 
 # JCSDA JEDI dependencies
 
-build_lib ecbuild
-build_lib eckit
-build_lib fckit
-build_lib atlas
+#build_lib ecbuild
+#build_lib eckit
+#build_lib fckit
+#build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/config/config_gaea.sh
+++ b/config/config_gaea.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="intel/18.0.6.288"
+export HPC_MPI="cray-mpich/7.7.11"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+
+# Load these basic modules for Gaea
+module load git/2.26.0
+module load cmake/3.17.0
+module switch intel/18.0.6.288
+
+export SERIAL_CC=cc
+export SERIAL_CXX=CC
+export SERIAL_FC=ftn
+
+export MPI_CC=cc
+export MPI_CXX=CC
+export MPI_FC=ftn
+
+# Load lmod environment
+source /lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/init/init_lmod.sh
+

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -166,7 +166,7 @@ crtm:
   install_as: 2.3.0
 
 nceppost:
-  build: YES
+  build: NO
   version: dceca26
   install_as: dceca26
   openmp: ON

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -171,6 +171,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -197,8 +197,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
   openmp: ON
 
 boost:

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -1,0 +1,256 @@
+cmake:
+  build: NO
+  version: 3.17.2
+
+jpeg:
+  build: YES
+  shared: NO
+  version: 9.1.0
+
+zlib:
+  build: YES
+  shared: NO
+  version: 1.2.11
+
+png:
+  build: YES
+  shared: NO
+  version: 1.6.35
+
+szip:
+  build: YES
+  shared: NO
+  version: 2.1.1
+
+jasper:
+  build: YES
+  shared: NO
+  version: 2.0.22
+
+udunits:
+  build: NO
+  shared: NO
+  version: 2.2.26
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: NO
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: NO
+
+netcdf:
+  build: YES
+  shared: NO
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.3
+  version_cxx: 4.3.1
+
+nccmp:
+  build: YES
+  version: 1.8.7.0
+
+nco:
+  build: NO
+  version: 4.9.3
+
+pio:
+  build: YES
+  version: 2.5.1
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: 8_1_0_beta_snapshot_27
+  shared: NO
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: NO
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+
+ip2:
+  build: NO
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+
+g2:
+  build: YES
+  version: v3.4.1
+  install_as: 3.4.1
+
+g2c:
+  build: NO
+  version: v1.6.2
+  install_as: 1.6.2
+
+g2tmpl:
+  build: YES
+  version: v1.9.1
+  install_as: 1.9.1
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+
+nceppost:
+  build: YES
+  version: dceca26
+  install_as: dceca26
+  openmp: ON
+
+wrf_io:
+  build: YES
+  version: v1.1.1-cmake-v5
+  install_as: 1.1.1
+  openmp: ON
+
+bufr:
+  build: YES
+  version: bufr_v11.4.0
+  install_as: 11.4.0
+
+wgrib2:
+  build: YES
+  version: v2.0.8-cmake-v5
+  install_as: 2.0.8
+  openmp: OFF
+  spectral: OFF
+  ipolates: 0
+
+prod_util:
+  build: YES
+  version: v1.2.1
+  install_as: 1.2.1
+
+grib_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  openmp: ON
+
+boost:
+  build: NO
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: NO
+  version: 3.3.7
+
+gsl_lite:
+  build: NO
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: NO
+  version: 3.9.1
+
+json_schema_validator:
+  build: NO
+  version: 2.1.0
+
+ecbuild:
+  build: NO
+  version: release-stable
+  repo: jcsda
+
+eckit:
+  build: NO
+  version: release-stable
+  repo: jcsda
+
+fckit:
+  build: NO
+  version: release-stable
+  repo: jcsda
+
+atlas:
+  build: NO
+  version: release-stable
+  repo: jcsda

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -166,7 +166,7 @@ crtm:
   install_as: 2.3.0
 
 nceppost:
-  build: YES
+  build: NO
   version: dceca26
   install_as: dceca26
   openmp: ON

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -171,6 +171,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -197,8 +197,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
   openmp: ON
 
 boost:

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -194,8 +194,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
   openmp: ON
 
 boost:

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -168,6 +168,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -194,8 +194,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
   openmp: ON
 
 boost:

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -168,6 +168,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -1,0 +1,202 @@
+gnu:
+  build: NO
+  version: 9.3.0
+
+mpi:
+  build: NO
+  flavor: openmpi
+  version: 4.0.1
+
+cmake:
+  build: NO
+  version: 3.17.2
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.22
+
+udunits:
+  build: YES
+  version: 2.2.26
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.3
+  version_cxx: 4.3.1
+
+nccmp:
+  build: YES
+  version: 1.8.7.0
+
+nco:
+  build: NO
+  version: 4.9.3
+
+pio:
+  build: YES
+  version: 2.5.1
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: 8_1_0_beta_snapshot_27
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: NO
+  version: master
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+
+ip2:
+  build: NO
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+
+g2:
+  build: YES
+  version: v3.4.1
+  install_as: 3.4.1
+
+g2c:
+  build: YES
+  version: v1.6.2
+  install_as: 1.6.2
+
+g2tmpl:
+  build: YES
+  version: v1.9.1
+  install_as: 1.9.1
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+
+nceppost:
+  build: YES
+  version: dceca26
+  install_as: dceca26
+  openmp: ON
+
+wrf_io:
+  build: YES
+  version: v1.1.1-cmake-v5
+  install_as: 1.1.1
+  openmp: ON
+
+bufr:
+  build: YES
+  version: bufr_v11.4.0
+  install_as: 11.4.0
+
+wgrib2:
+  build: YES
+  version: v2.0.8-cmake-v5
+  install_as: 2.0.8
+  openmp: OFF
+  spectral: OFF
+  ipolates: 0
+
+prod_util:
+  build: YES
+  version: v1.2.1
+  install_as: 1.2.1
+
+grib_util:
+  build: YES
+  version: v1.2.1
+  install_as: 1.2.1
+  openmp: ON

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -197,6 +197,6 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
   openmp: ON

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -11,8 +11,8 @@ software=${name}_$version
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
-COMPILER=$(echo $compiler | cut -d- -f1)
-MPI=$(echo $mpi | cut -d- -f1)
+COMPILER=$(echo $HPC_COMPILER | cut -d/ -f1)
+MPI=$(echo $HPC_MPI | cut -d/ -f1)
 
 [[ $STACK_esmf_enable_pnetcdf =~ [yYtT] ]] && enable_pnetcdf=YES || enable_pnetcdf=NO
 [[ ${STACK_esmf_shared} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
@@ -75,8 +75,6 @@ software="ESMF_$version"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 export ESMF_DIR=$PWD
 
-export ESMF_OS=$(uname -s)
-
 # This is going to need a little work to adapt for various combinations
 # of Darwin/Linux with GNU/Clang/Intel etc.
 case $COMPILER in
@@ -96,26 +94,24 @@ case $COMPILER in
     ;;
 esac
 
-#  mpiexec --version | grep OpenRTE 2> /dev/null && export ESMF_COMM=openmpi
-#  mpiexec --version | grep Intel   2> /dev/null && export ESMF_COMM=intelmpi
-export ESMF_MPIRUN=mpiexec
 case $MPI in
   openmpi )
     export ESMF_COMM="openmpi"
     ;;
   mpich )
-    export ESMF_COMM="mpich3"
+    export ESMF_COMM=${STACK_esmf_comm:-"mpich3"}
+    ;;
+  cray-mpich )
+    export ESMF_COMM=${STACK_esmf_comm:-"mpi"}
     ;;
   impi )
     export ESMF_COMM="intelmpi"
     ;;
   mpt )
     export ESMF_COMM="mpt"
-    export ESMF_MPIRUN=mpiexec_mpt
     ;;
   * )
     export ESMF_COMM="mpiuni"
-    export ESMF_MPIRUN=""
     ;;
 esac
 

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -80,7 +80,7 @@ if $MODULES; then
       module load sigio
       module load nemsio
       ;;
-    nceppost)
+    nceppost | upp)
       mpi=$mpi_check
       [[ -z $mpi ]] && ( echo "$name requires MPI, ABORT!"; exit 1 )
       module load hpc-$HPC_MPI
@@ -155,7 +155,7 @@ export FCFLAGS="$FFLAGS"
 gitURL="https://github.com/noaa-emc/nceplibs-$name"
 extraCMakeFlags=""
 case $name in
-  nceppost)
+  nceppost | upp)
     gitURL="https://github.com/noaa-emc/emc_post"
     extraCMakeFlags="-DBUILD_POSTEXEC=OFF"
     ;;

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-cray-mpich/hpc-cray-mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-cray-mpich/hpc-cray-mpich.lua
@@ -10,21 +10,21 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-cray-mpich","hpc-mpich","hpc-mpt","hpc-openmpi")
+conflict("hpc-impi","hpc-mpich","hpc-mpt","hpc-openmpi")
 
-local mpi = pathJoin("impi",pkgVersion)
+local mpi = pathJoin("cray-mpich",pkgVersion)
 load(mpi)
 prereq(mpi)
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
-local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"impi",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"cray-mpich",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
-setenv("MPI_FC",  "mpiifort")
-setenv("MPI_CC",  "mpiicc")
-setenv("MPI_CXX", "mpiicpc")
+setenv("MPI_FC",  "ftn")
+setenv("MPI_CC",  "cc")
+setenv("MPI_CXX", "CC")
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: library")
-whatis("Description: Intel MPI library and module access")
+whatis("Description: Cray MPICH Library and module access")

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-mpich/hpc-mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-mpich/hpc-mpich.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-openmpi","hpc-impi")
+conflict("hpc-cray-mpich","hpc-impi","hpc-mpt","hpc-openmpi")
 
 local mpi = pathJoin("mpich",pkgVersion)
 load(mpi)

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-mpt/hpc-mpt.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-mpt/hpc-mpt.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-openmpi","hpc-mpich","hpc-impi")
+conflict("hpc-cray-mpich","hpc-impi","hpc-mpich","hpc-openmpi")
 
 local mpi = pathJoin("mpt",pkgVersion)
 load(mpi)

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-openmpi/hpc-openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-openmpi/hpc-openmpi.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-mpich","hpc-impi")
+conflict("hpc-cray-mpich","hpc-impi","hpc-mpich","hpc-mpt")
 
 local mpi = pathJoin("openmpi",pkgVersion)
 load(mpi)

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
@@ -1,0 +1,35 @@
+help([[
+]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+load("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+prereq("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+setenv("upp_ROOT", base)
+setenv("upp_VERSION", pkgVersion)
+setenv("NCEPPOST_INC", pathJoin(base,"include"))
+setenv("NCEPPOST_LIB", pathJoin(base,"lib/libupp.a"))
+setenv("POST_INC", pathJoin(base,"include"))
+setenv("POST_LIB", pathJoin(base,"lib/libupp.a"))
+setenv("UPP_INC", pathJoin(base,"include"))
+setenv("UPP_LIB", pathJoin(base,"lib/libupp.a"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")

--- a/setup_modules.sh
+++ b/setup_modules.sh
@@ -89,50 +89,87 @@ $SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion
 $SUDO mkdir -p $PREFIX/modulefiles/mpi/$compilerName/$compilerVersion/$mpiName/$mpiVersion
 
 $SUDO mkdir -p $PREFIX/modulefiles/core/hpc-$compilerName
-$SUDO cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
-         $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
-
 $SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
-$SUDO cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
-         $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
 
-#===============================================================================
-# Query the user if using native compiler and MPI
-echo "Are you using native compiler $compilerName [yes|YES|no|NO]: (DEFAULT: NO)  "
-read responseCompiler
-if [[ $responseCompiler =~ [yYtT] ]]; then
-  echo -e "==========================\n USING NATIVE COMPILER"
-  cd $PREFIX/modulefiles/core/hpc-$compilerName
-  $SUDO sed -i -e '/load(compiler)/d' $compilerVersion.lua
-  $SUDO sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
-  [[ -f $compilerVersion.lua-e ]] && $SUDO rm -f "$compilerVersion.lua-e" # Stupid macOS does not understand -i, and creates a backup with -e (-e is the next sed option)
-  echo
-fi
-
-echo "Are you using native MPI $mpiName [yes|YES|no|NO]: (DEFAULT: NO)  "
-read responseMPI
-if [[ $responseMPI =~ [yYtT] ]]; then
-  echo -e "===========================\n USING NATIVE MPI"
-  cd $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
-  $SUDO sed -i -e '/load(mpi)/d' $mpiVersion.lua
-  $SUDO sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
-  [[ -f $mpiVersion.lua-e ]] && $SUDO rm -f "$mpiVersion.lua-e"
-  echo
-fi
-
-#===============================================================================
-
-# Deploy directory for stack modulefile
 $SUDO mkdir -p $PREFIX/modulefiles/stack/hpc
-$SUDO cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
-         $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
 
-# Replace #PREFIX# from template with $PREFIX,
-# sed does not like delimiter (/) to be a part of replacement string, do magic!
-cd $PREFIX/modulefiles/stack/hpc
-repl=$(echo ${PREFIX} | sed -e "s#/#\\\/#g")
-$SUDO sed -i -e "s/#HPC_OPT#/${repl}/g" $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
-[[ -f $HPC_STACK_VERSION.lua-e ]] && $SUDO rm -f "$HPC_STACK_VERSION.lua-e"
+#===============================================================================
+# Are the hpc-$compilerName.lua, hpc-$mpiName.lua or hpc/stack.lua modulefiles present at $PREFIX?
+# If yes, query the user to ask to over-write
+if [[ -f $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua ]]; then
+  echo "WARNING: $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua exists!"
+  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+  read response
+else
+  response="YES"
+fi
+[[ $response =~ [yYtT] ]] && overwriteCompilerModulefile=YES
+unset response
+
+if [[ -f $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua ]]; then
+  echo "WARNING: $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua exists!"
+  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+  read response
+else
+  response="YES"
+fi
+[[ $response =~ [yYtT] ]] && overwriteMPIModulefile=YES
+unset response
+
+if [[ -f $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua ]]; then
+  echo "WARNING: $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua exists!"
+  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+  read response
+else
+  response="YES"
+fi
+[[ $response =~ [yYtT] ]] && overwriteStackModulefile=YES
+unset response
+
+#===============================================================================
+# Query the user if using native compiler and MPI, if overwriting (or writing for first time)
+if [[ ${overwriteCompilerModulefile:-} =~ [yYtT] ]]; then
+  $SUDO cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
+           $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
+  echo "Are you using native compiler $compilerName [yes|YES|no|NO]: (DEFAULT: NO)  "
+  read response
+  if [[ $response =~ [yYtT] ]]; then
+    echo -e "==========================\n USING NATIVE COMPILER"
+    cd $PREFIX/modulefiles/core/hpc-$compilerName
+    $SUDO sed -i -e '/load(compiler)/d' $compilerVersion.lua
+    $SUDO sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
+    [[ -f $compilerVersion.lua-e ]] && $SUDO rm -f "$compilerVersion.lua-e" # Stupid macOS does not understand -i, and creates a backup with -e (-e is the next sed option)
+    echo
+  fi
+  unset response
+fi
+
+if [[ ${overwriteMPIModulefile:-} =~ [yYtT] ]]; then
+  $SUDO cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
+           $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
+  echo "Are you using native MPI $mpiName [yes|YES|no|NO]: (DEFAULT: NO)  "
+  read response
+  if [[ $response =~ [yYtT] ]]; then
+    echo -e "===========================\n USING NATIVE MPI"
+    cd $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
+    $SUDO sed -i -e '/load(mpi)/d' $mpiVersion.lua
+    $SUDO sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
+    [[ -f $mpiVersion.lua-e ]] && $SUDO rm -f "$mpiVersion.lua-e"
+    echo
+  fi
+  unset response
+fi
+
+if [[ ${overwriteStackModulefile:-} =~ [yYtT] ]]; then
+  $SUDO cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
+           $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+  # Replace #PREFIX# from template with $PREFIX,
+  # sed does not like delimiter (/) to be a part of replacement string, do magic!
+  cd $PREFIX/modulefiles/stack/hpc
+  repl=$(echo ${PREFIX} | sed -e "s#/#\\\/#g")
+  $SUDO sed -i -e "s/#HPC_OPT#/${repl}/g" $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+  [[ -f $HPC_STACK_VERSION.lua-e ]] && $SUDO rm -f "$HPC_STACK_VERSION.lua-e"
+fi
 
 #===============================================================================
 


### PR DESCRIPTION
This PR:
- adds UPP v10 to the hpc-stack
- retains nceppost until it is ready to be removed and replaced by UPP for post library in UFS
- fixes #31 

Change-Id: I09a155ef0e026d8fac682390f05e9c2dd9c7c2d4