### PR TITLE
Update wgrib2 with fixes for CMake build

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -120,7 +120,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -190,16 +190,16 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  openmp: ON
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES
-  version: v1.2.1
-  install_as: 1.2.1
+  version: v1.2.2
+  install_as: 1.2.2
 
 grib_util:
   build: YES

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -117,7 +117,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -181,11 +181,11 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  openmp: ON
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -120,7 +120,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -190,11 +190,11 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
   openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -117,7 +117,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -187,11 +187,11 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  openmp: ON
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -117,7 +117,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -187,11 +187,11 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  openmp: ON
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -120,7 +120,7 @@ ip:
   openmp: ON
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
@@ -184,11 +184,11 @@ bufr:
 
 wgrib2:
   build: YES
-  version: v2.0.8-cmake-v5
+  version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
-  spectral: OFF
-  ipolates: 0
+  openmp: ON
+  spectral: ON
+  ipolates: 3
 
 prod_util:
   build: YES

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -43,8 +43,8 @@ if $MODULES; then
       module try-load zlib
       module try-load png
       module load netcdf
-      #module load sp  # building with USE_SPECTRAL=OFF
-      #module load ip2 # building with USE_IPOLATES=0
+      module load sp
+      module load ip2
       ;;
     ip2)
       module load sp


### PR DESCRIPTION
Update wgrib2 to `v2.0.8-cmake-v6` with fixes in the CMake build

Also re-enable building wgrib2 with USE_IPOLATES enabled

Fixes #75 and #80 