### PR TITLE
Add UPP to the stack.

### DIFF
--- a/build_stack.sh
+++ b/build_stack.sh
@@ -151,7 +151,7 @@ build_lib pio
 
 # UFS 3rd party dependencies
 
-#build_lib esmf
+build_lib esmf
 build_lib fms
 
 # NCEPlibs
@@ -182,22 +182,22 @@ build_nceplib grib_util
 
 # JEDI 3rd party dependencies
 
-#build_lib boost
-#build_lib eigen
-#build_lib gsl_lite
-#build_lib gptl
-#build_lib fftw
-#build_lib tau2
-#build_lib cgal
-#build_lib json
-#build_lib json_schema_validator
+build_lib boost
+build_lib eigen
+build_lib gsl_lite
+build_lib gptl
+build_lib fftw
+build_lib tau2
+build_lib cgal
+build_lib json
+build_lib json_schema_validator
 
 # JCSDA JEDI dependencies
 
-#build_lib ecbuild
-#build_lib eckit
-#build_lib fckit
-#build_lib atlas
+build_lib ecbuild
+build_lib eckit
+build_lib fckit
+build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -173,6 +173,7 @@ build_nceplib g2c
 build_nceplib g2tmpl
 build_nceplib crtm
 build_nceplib nceppost
+build_nceplib upp
 build_nceplib wrf_io
 build_nceplib bufr
 build_nceplib wgrib2

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -151,7 +151,7 @@ build_lib pio
 
 # UFS 3rd party dependencies
 
-build_lib esmf
+#build_lib esmf
 build_lib fms
 
 # NCEPlibs
@@ -182,22 +182,22 @@ build_nceplib grib_util
 
 # JEDI 3rd party dependencies
 
-build_lib boost
-build_lib eigen
-build_lib gsl_lite
-build_lib gptl
-build_lib fftw
-build_lib tau2
-build_lib cgal
-build_lib json
-build_lib json_schema_validator
+#build_lib boost
+#build_lib eigen
+#build_lib gsl_lite
+#build_lib gptl
+#build_lib fftw
+#build_lib tau2
+#build_lib cgal
+#build_lib json
+#build_lib json_schema_validator
 
 # JCSDA JEDI dependencies
 
-build_lib ecbuild
-build_lib eckit
-build_lib fckit
-build_lib atlas
+#build_lib ecbuild
+#build_lib eckit
+#build_lib fckit
+#build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -166,7 +166,7 @@ crtm:
   install_as: 2.3.0
 
 nceppost:
-  build: YES
+  build: NO
   version: dceca26
   install_as: dceca26
   openmp: ON

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -171,6 +171,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -166,7 +166,7 @@ crtm:
   install_as: 2.3.0
 
 nceppost:
-  build: YES
+  build: NO
   version: dceca26
   install_as: dceca26
   openmp: ON

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -171,6 +171,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -168,6 +168,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -168,6 +168,12 @@ nceppost:
   install_as: dceca26
   openmp: ON
 
+upp:
+  build: YES
+  version: upp_v10.0.0
+  install_as: 10.0.0
+  openmp: ON
+
 wrf_io:
   build: YES
   version: v1.1.1-cmake-v5

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -80,7 +80,7 @@ if $MODULES; then
       module load sigio
       module load nemsio
       ;;
-    nceppost)
+    nceppost | upp)
       mpi=$mpi_check
       [[ -z $mpi ]] && ( echo "$name requires MPI, ABORT!"; exit 1 )
       module load hpc-$HPC_MPI
@@ -155,7 +155,7 @@ export FCFLAGS="$FFLAGS"
 gitURL="https://github.com/noaa-emc/nceplibs-$name"
 extraCMakeFlags=""
 case $name in
-  nceppost)
+  nceppost | upp)
     gitURL="https://github.com/noaa-emc/emc_post"
     extraCMakeFlags="-DBUILD_POSTEXEC=OFF"
     ;;

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
@@ -1,0 +1,35 @@
+help([[
+]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+load("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+prereq("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+setenv("upp_ROOT", base)
+setenv("upp_VERSION", pkgVersion)
+setenv("NCEPPOST_INC", pathJoin(base,"include"))
+setenv("NCEPPOST_LIB", pathJoin(base,"lib/libupp.a"))
+setenv("POST_INC", pathJoin(base,"include"))
+setenv("POST_LIB", pathJoin(base,"lib/libupp.a"))
+setenv("UPP_INC", pathJoin(base,"include"))
+setenv("UPP_LIB", pathJoin(base,"lib/libupp.a"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")


### PR DESCRIPTION
This PR:
- adds UPP v10 to the hpc-stack
- retains nceppost until it is ready to be removed and replaced by UPP for post library in UFS (except in the CI yamls)
- fixes #31

This is a follow-up PR to #63 