### PR TITLE
Disable building nceppost for container

### DIFF
--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -166,7 +166,7 @@ crtm:
   install_as: 2.3.0
 
 nceppost:
-  build: YES
+  build: NO
   version: dceca26
   install_as: dceca26
   openmp: ON


### PR DESCRIPTION
If building `nceppost` and UPP v10.0.0 in a flat structure (like a container) the Fortran module names conflict.

Fixes #71 
