### PR TITLE
Revert ESMF to beta 27

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -71,7 +71,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -68,7 +68,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -71,7 +71,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -68,7 +68,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -68,7 +68,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -71,7 +71,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_36
+  version: 8_1_0_beta_snapshot_27
   shared: YES
   enable_pnetcdf: NO
   debug: NO


### PR DESCRIPTION
The weather model's develop branch still uses 27 and it fails to build with 36 out-of-the-box.

Beta 36 will still be installed alongside beta 27 on NOAA HPC systems as requested by @junwang-noaa in #41, but beta 27 will be the default in the stack files.

Fixes #105 


