### PR TITLE
Install ESMF beta 21 on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ setenv("LMOD_EXACT_MATCH", "no")
 setenv("LMOD_EXTENDED_DEFAULT", "yes")
 ```
 
+## Known Issues
+
+- ESMF beta snapshot 27 does not work on macOS. `stack_mac` installs
+  beta 21 instead.
+
 ## Disclaimer
 
 The United States Department of Commerce (DOC) GitHub project code is

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -71,7 +71,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_21
   shared: YES
   enable_pnetcdf: NO
   debug: NO


### PR DESCRIPTION
ESMF beta 27 does not work on macOS. Update `stack_mac` to install beta 21.

https://github.com/ufs-community/ufs-weather-model/issues/303

https://github.com/NOAA-EMC/hpc-stack/issues/111#issuecomment-735869981