### PR TITLE
Final touches for macOS for v.1.1.0 release (stack_mac.yaml, build_esmf.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,11 @@ setenv("LMOD_EXTENDED_DEFAULT", "yes")
 - ESMF beta snapshot 27 does not work on macOS. `stack_mac` installs
   beta 21 instead.
 
-- NetCDF-C++ does not build with LLVM Clang. It can be disabled  by setting
+- NetCDF-C++ does not build with LLVM Clang. It can be disabled by setting
 `disable_cxx: YES` in the stack file under the NetCDF section.
+
+- Json-schema-validator does not build with LLVM Clang. It can be disabled
+in the stack file in the json-schema-validator-section.
 
 ## Disclaimer
 

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -242,25 +242,25 @@ json:
   version: 3.9.1
 
 json_schema_validator:
-  build: NO
+  build: YES
   version: 2.1.0
 
 ecbuild:
-  build: NO
+  build: YES
   version: release-stable
   repo: jcsda
 
 eckit:
-  build: NO
+  build: YES
   version: release-stable
   repo: jcsda
 
 fckit:
-  build: NO
+  build: YES
   version: release-stable
   repo: jcsda
 
 atlas:
-  build: NO
+  build: YES
   version: release-stable
   repo: jcsda

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -38,22 +38,23 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: YES
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: YES
+  shared: NO
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
+  disable_cxx: YES
 
 nccmp:
   build: YES
@@ -72,7 +73,7 @@ pio:
 esmf:
   build: YES
   version: 8_1_0_beta_snapshot_21
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   debug: NO
 
@@ -241,25 +242,25 @@ json:
   version: 3.9.1
 
 json_schema_validator:
-  build: YES
+  build: NO
   version: 2.1.0
 
 ecbuild:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 eckit:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 fckit:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 atlas:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda


### PR DESCRIPTION
Final bunch of changes require for v1.1.0 release on macOS.

- Update libs/build_esmf.sh with correct compiler flags for macOS and other platforms
- Build static packages by default on macOS, turn off json-schema-validator and several jedi packages that may depend on it

The settings/flags in `libs/build_esmf.sh` correspond to what we have been using to install ESMF manually on all platforms as per guidance by the ESMF group.

This works on my mac with Apple Clang + GNU Fortran, LLVM Clang + GNU Fortran, GNU C + Fortran.