### PR TITLE
fix: mpi local variable not set for "no modules" configuration

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -129,6 +129,7 @@ if $MODULES; then
 else
     nameUpper=$(echo $name | tr [a-z] [A-Z])
     eval prefix="\${${nameUpper}_ROOT:-'/usr/local'}"
+    [[ ! -z $mpi_check ]] && mpi=$mpi_check
 fi
 
 if [[ ! -z $mpi ]]; then


### PR DESCRIPTION
body: During the setup for the build_nceplibs.sh script, the
local variable 'mpi' is not set to local variable 'mpi_check'
as it is in the "use modules" case. Several ncep libraries rely
 on this local variable 'mpi' downstream to set the the compile
 flags (FC, CC, CXX).

This pull request fixes issue #122

id: #122