### PR TITLE
Correct szip option in hdf5.

### DIFF
--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -63,7 +63,7 @@ mkdir -p build && cd build
 [[ -z $mpi ]] || extra_conf="--enable-parallel --enable-unsupported"
 
 [[ $enable_shared =~ [yYtT] ]] || shared_flags="--disable-shared --enable-static --enable-static-exec"
-[[ $enable_szip =~ [yYtT] ]] && szip_flags="--with-szip=$SZIP_ROOT"
+[[ $enable_szip =~ [yYtT] ]] && szip_flags="--with-szlib=$SZIP_ROOT"
 [[ $enable_zlib =~ [yYtT] ]] && zlib_flags="--with-zlib=$ZLIB_ROOT"
 
 ../configure --prefix=$prefix \


### PR DESCRIPTION
fixes #126 

This PR corrects the SZip option in hdf5.