### PR TITLE
Add option to build with multiple compilers/MPIs at once

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="gnu/9.1.0"
-export HPC_MPI="mpt/2.22"
+export HPC_COMPILER=("gnu/9.1.0")
+export HPC_MPI=("mpt/2.22")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/19.1.1"
-export HPC_MPI="mpt/2.22"
+export HPC_COMPILER=("intel/19.1.1")
+export HPC_MPI=("mpt/2.22")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_custom.sh
+++ b/config/config_custom.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER=${HPC_COMPILER:-"gnu/9.3.0"}
-export HPC_MPI=${HPC_MPI:-"openmpi/4.0.1"}
+export HPC_COMPILER=("gnu/9.3.0")
+export HPC_MPI=("openmpi/4.0.1")
+export BUILD_MPIS=("NO")
 
 # Build options
 export USE_SUDO=N

--- a/config/config_gaea.sh
+++ b/config/config_gaea.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.6.288"
-export HPC_MPI="cray-mpich/7.7.11"
+export HPC_COMPILER=("intel/18.0.6.288")
+export HPC_MPI=("cray-mpich/7.7.11")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.5.274"
-export HPC_MPI="impi/2018.0.4"
+export HPC_COMPILER=("intel/18.0.5.274")
+export HPC_MPI=("impi/2018.0.4")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_linux_ubuntu20_intel_oneapi_beta09.sh
+++ b/config/config_linux_ubuntu20_intel_oneapi_beta09.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER=${HPC_COMPILER:-"intel/oneapi-beta09"}
-export HPC_MPI=${HPC_MPI:-"impi/oneapi-beta09"}
+export HPC_COMPILER=("intel/oneapi-beta09")
+export HPC_MPI=("impi/oneapi-beta09")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_mac.sh
+++ b/config/config_mac.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="clang/11.0.3"
-export HPC_MPI="mpich/3.3.1"
+export HPC_COMPILER=("clang/11.0.3")
+export HPC_MPI=("mpich/3.3.1")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_orion.sh
+++ b/config/config_orion.sh
@@ -5,10 +5,12 @@
 #export HPC_MPI="impi/2019.6"
 #export HPC_COMPILER="intel/2018.4"
 #export HPC_MPI="impi/2018.4"
-export HPC_COMPILER="intel/2020"
-export HPC_MPI="impi/2020"
+export HPC_COMPILER=("intel/2020")
+export HPC_MPI=("impi/2020")
 #export HPC_COMPILER="gcc/8.3.0"
 #export HPC_MPI="openmpi/4.0.2"
+
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/config_wcoss_dell_p3.sh
+++ b/config/config_wcoss_dell_p3.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="ips/18.0.1.163"
-export HPC_MPI="impi/18.0.1"
+export HPC_COMPILER=("ips/18.0.1.163")
+export HPC_MPI=("impi/18.0.1")
+export BUILD_MPIS=(NO)
 
 # Build options
 export USE_SUDO=N

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -16,27 +16,27 @@ jpeg:
   version: 9.1.0
 
 zlib:
-  build: YES
+  build: NO
   version: 1.2.11
 
 png:
-  build: YES
+  build: NO
   version: 1.6.35
 
 szip:
-  build: YES
+  build: NO
   version: 2.1.1
 
 jasper:
-  build: YES
+  build: NO
   version: 2.0.22
 
 udunits:
-  build: YES
+  build: NO
   version: 2.2.26
 
 hdf5:
-  build: YES
+  build: NO
   version: 1.10.6
   shared: YES
   enable_szip: NO
@@ -48,7 +48,7 @@ pnetcdf:
   shared: YES
 
 netcdf:
-  build: YES
+  build: NO
   shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
@@ -56,7 +56,7 @@ netcdf:
   version_cxx: 4.3.1
 
 nccmp:
-  build: YES
+  build: NO
   version: 1.8.7.0
 
 nco:
@@ -64,17 +64,17 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: YES
+  build: NO
   version: 1.9.8
 
 pio:
-  build: YES
+  build: NO
   version: 2.5.1
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
-  build: YES
+  build: NO
   version: 8_1_0_beta_snapshot_27
   shared: YES
   enable_pnetcdf: NO
@@ -87,85 +87,85 @@ fms:
   cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
 
 bacio:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
 
 sigio:
-  build: YES
+  build: NO
   version: v2.3.2
   install_as: 2.3.2
 
 sfcio:
-  build: YES
+  build: NO
   version: v1.4.1
   install_as: 1.4.1
 
 gfsio:
-  build: YES
+  build: NO
   version: v1.4.1
   install_as: 1.4.1
 
 w3nco:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
 
 sp:
-  build: YES
+  build: NO
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
 
 ip:
-  build: YES
+  build: NO
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
 
 ip2:
-  build: YES
+  build: NO
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
 
 landsfcutil:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
 
 nemsio:
-  build: YES
+  build: NO
   version: v2.5.2
   install_as: 2.5.2
 
 nemsiogfs:
-  build: YES
+  build: NO
   version: v2.5.3
   install_as: 2.5.3
 
 w3emc:
-  build: YES
+  build: NO
   version: v2.7.3
   install_as: 2.7.3
 
 g2:
-  build: YES
+  build: NO
   version: v3.4.1
   install_as: 3.4.1
 
 g2c:
-  build: YES
+  build: NO
   version: v1.6.2
   install_as: 1.6.2
 
 g2tmpl:
-  build: YES
+  build: NO
   version: v1.9.1
   install_as: 1.9.1
 
 crtm:
-  build: YES
+  build: NO
   version: v2.3.0
   install_as: 2.3.0
 
@@ -176,24 +176,24 @@ nceppost:
   openmp: ON
 
 upp:
-  build: YES
+  build: NO
   version: upp_v10.0.0
   install_as: 10.0.0
   openmp: ON
 
 wrf_io:
-  build: YES
+  build: NO
   version: v1.1.1-cmake-v5
   install_as: 1.1.1
   openmp: ON
 
 bufr:
-  build: YES
+  build: NO
   version: bufr_v11.4.0
   install_as: 11.4.0
 
 wgrib2:
-  build: YES
+  build: NO
   version: v2.0.8-cmake-v6
   install_as: 2.0.8
   openmp: ON
@@ -201,27 +201,27 @@ wgrib2:
   ipolates: 3
 
 prod_util:
-  build: YES
+  build: NO
   version: v1.2.2
   install_as: 1.2.2
 
 grib_util:
-  build: YES
+  build: NO
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
 
 boost:
-  build: YES
+  build: NO
   version: 1.68.0
   level: headers-only
 
 eigen:
-  build: YES
+  build: NO
   version: 3.3.7
 
 gsl_lite:
-  build: YES
+  build: NO
   version: 0.37.0
 
 gptl:
@@ -241,29 +241,29 @@ cgal:
   version: 5.0.2
 
 json:
-  build: YES
+  build: NO
   version: 3.9.1
 
 json_schema_validator:
-  build: YES
+  build: NO
   version: 2.1.0
 
 ecbuild:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 eckit:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 fckit:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda
 
 atlas:
-  build: YES
+  build: NO
   version: release-stable
   repo: jcsda


### PR DESCRIPTION
HPC_COMPILER has become HPC_COMPILERS and HPC_MPI has become HPC_MPIS, and are now arrays, and setup_modules and build_stack will loop through and compile the libraries for each all at once.

Add a BUILD_MPIS option so that the flavor/version of MPI to build is set through HPC_MPI variable and controlled by setting YES/NO for the corresponding entry in BUILD_MPIS


Thoughts on this @aerorahul?

Now you can build each compiler variation all at once instead of having to re-run the setup and build scripts.

I did this so I could build Intel and GNU for my Cron testing scripts, but I think it will be useful in general.