### PR TITLE
Create loop_stack.sh to build multiple compiler/MPI combinations at once

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="gnu/9.1.0"
-export HPC_MPI="mpt/2.22"
+export HPC_COMPILER=${HPC_COMPILER:-"gnu/9.1.0"}
+export HPC_MPI=${HPC_MPI:-"mpt/2.22"}
 
 # Build options
 export USE_SUDO=N

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/19.1.1"
-export HPC_MPI="mpt/2.22"
+export HPC_COMPILER=${HPC_COMPILER:-"intel/19.1.1"}
+export HPC_MPI=${HPC_MPI:-"mpt/2.22"}
 
 # Build options
 export USE_SUDO=N

--- a/config/config_gaea.sh
+++ b/config/config_gaea.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.6.288"
-export HPC_MPI="cray-mpich/7.7.11"
+export HPC_COMPILER=${HPC_COMPILER:-"intel/18.0.6.288"}
+export HPC_MPI=${HPC_MPI:-"cray-mpich/7.7.11"}
 
 # Build options
 export USE_SUDO=N

--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.5.274"
-export HPC_MPI="impi/2018.0.4"
+export HPC_COMPILER=${HPC_COMPILER:-"intel/18.0.5.274"}
+export HPC_MPI=${HPC_MPI:-"impi/2018.0.4"}
 
 # Build options
 export USE_SUDO=N

--- a/config/config_mac.sh
+++ b/config/config_mac.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="clang/11.0.3"
-export HPC_MPI="mpich/3.3.1"
+export HPC_COMPILER=${HPC_COMPILER:-"clang/11.0.3"}
+export HPC_MPI=${HPC_MPI:-"mpich/3.3.1"}
 
 # Build options
 export USE_SUDO=N

--- a/config/config_orion.sh
+++ b/config/config_orion.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
+export HPC_COMPILERS=("intel/2018.4" "intel/2019.5" "intel/2020" "gcc/8.3.0")
+export HPC_MPIS=("impi/2018.4" "impi/2019.6" "impi/2020" "openmpi/4.0.2")
+
 # Compiler/MPI combination
-#export HPC_COMPILER="intel/2019.5"
-#export HPC_MPI="impi/2019.6"
-#export HPC_COMPILER="intel/2018.4"
-#export HPC_MPI="impi/2018.4"
 export HPC_COMPILER=${HPC_COMPILER:-"intel/2020"}
 export HPC_MPI=${HPC_MPI:-"impi/2020"}
-#export HPC_COMPILER="gcc/8.3.0"
-#export HPC_MPI="openmpi/4.0.2"
 
 # Build options
 export USE_SUDO=N

--- a/config/config_orion.sh
+++ b/config/config_orion.sh
@@ -5,8 +5,8 @@
 #export HPC_MPI="impi/2019.6"
 #export HPC_COMPILER="intel/2018.4"
 #export HPC_MPI="impi/2018.4"
-export HPC_COMPILER="intel/2020"
-export HPC_MPI="impi/2020"
+export HPC_COMPILER=${HPC_COMPILER:-"intel/2020"}
+export HPC_MPI=${HPC_MPI:-"impi/2020"}
 #export HPC_COMPILER="gcc/8.3.0"
 #export HPC_MPI="openmpi/4.0.2"
 

--- a/config/config_wcoss_dell_p3.sh
+++ b/config/config_wcoss_dell_p3.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="ips/18.0.1.163"
-export HPC_MPI="impi/18.0.1"
+export HPC_COMPILER=${HPC_COMPILER:-"ips/18.0.1.163"}
+export HPC_MPI=${HPC_MPI:-"impi/18.0.1"}
 
 # Build options
 export USE_SUDO=N

--- a/loop_stack.sh
+++ b/loop_stack.sh
@@ -18,13 +18,11 @@ usage() {
   exit 1
 }
 
-# ==============================================================================
-
-[[ $# -eq 0 ]] && usage
 
 # Defaults:
 export PREFIX="$HOME/opt"
 config="${HPC_STACK_ROOT}/config/config_custom.sh"
+yaml="${HPC_STACK_ROOT}/config/stack_custom.yaml"
 
 while getopts ":p:c:y:h" opt; do
   case $opt in

--- a/loop_stack.sh
+++ b/loop_stack.sh
@@ -35,7 +35,7 @@ while getopts ":p:c:y:h" opt; do
       config=$OPTARG
       ;;
     y)
-      single_yaml=$OPTARG
+      yaml=$OPTARG
       ;;
     h|\?|:)
       usage
@@ -61,11 +61,6 @@ if [[ -z ${HPC_MPIS+x} ]]; then
     exit 1
 fi
 
-if [[ -z ${single_yaml+x} && -z ${HPC_YAMLS+x} ]]; then
-    echo "HPC_YAMLS must be set in config or -y must be passed to loop_stack.sh"
-    exit 1
-fi
-
 for index in ${!HPC_COMPILERS[*]}; do
     export HPC_COMPILER=${HPC_COMPILERS[$index]}
     export HPC_MPI=${HPC_MPIS[$index]}
@@ -77,12 +72,6 @@ done
 for index in ${!HPC_COMPILERS[*]}; do
     export HPC_COMPILER=${HPC_COMPILERS[$index]}
     export HPC_MPI=${HPC_MPIS[$index]}
-
-    if [[ ! -z ${single_yaml+x} ]]; then
-        yaml=$single_yaml
-    else
-        yaml=${HPC_YAMLS[$index]}
-    fi
   
     ${HPC_STACK_ROOT}/build_stack.sh -p $PREFIX -c $config -y $yaml -m
 done

--- a/loop_stack.sh
+++ b/loop_stack.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -eux
+
+# root directory for the repository
+export HPC_STACK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+usage() {
+  set +x
+  echo
+  echo "Usage: $0 -p <prefix> | -c <config> | -y <yaml> -h"
+  echo
+  echo "  -p  installation prefix <prefix>    DEFAULT: $HOME/opt"
+  echo "  -c  use configuration file <config> DEFAULT: config/config_custom.sh"
+  echo "  -y  use yaml file <yaml>            DEFAULT: config/stack_custom.yaml"
+  echo "  -h  display this message and quit"
+  echo
+  exit 1
+}
+
+# ==============================================================================
+
+[[ $# -eq 0 ]] && usage
+
+# Defaults:
+export PREFIX="$HOME/opt"
+config="${HPC_STACK_ROOT}/config/config_custom.sh"
+
+while getopts ":p:c:y:h" opt; do
+  case $opt in
+    p)
+      export PREFIX=$OPTARG
+      ;;
+    c)
+      config=$OPTARG
+      ;;
+    y)
+      single_yaml=$OPTARG
+      ;;
+    h|\?|:)
+      usage
+      ;;
+  esac
+done
+
+# Source the config file
+if [[ -e $config ]]; then
+    source $config
+else
+    echo "ERROR: CONFIG FILE $config DOES NOT EXIST, ABORT!"
+    exit 1
+fi
+
+if [[ -z ${HPC_COMPILERS+x} ]]; then
+    echo "HPC_COMPILERS array must be set in config to use loop_stack.sh"
+    exit 1
+fi
+
+if [[ -z ${HPC_MPIS+x} ]]; then
+    echo "HPC_MPIS array must be set in config to use loop_stack.sh"
+    exit 1
+fi
+
+if [[ -z ${single_yaml+x} && -z ${HPC_YAMLS+x} ]]; then
+    echo "HPC_YAMLS must be set in config or -y must be passed to loop_stack.sh"
+    exit 1
+fi
+
+for index in ${!HPC_COMPILERS[*]}; do
+    export HPC_COMPILER=${HPC_COMPILERS[$index]}
+    export HPC_MPI=${HPC_MPIS[$index]}
+    
+    ${HPC_STACK_ROOT}/setup_modules.sh -O -p $PREFIX -c $config
+done
+
+
+for index in ${!HPC_COMPILERS[*]}; do
+    export HPC_COMPILER=${HPC_COMPILERS[$index]}
+    export HPC_MPI=${HPC_MPIS[$index]}
+
+    if [[ ! -z ${single_yaml+x} ]]; then
+        yaml=$single_yaml
+    else
+        yaml=${HPC_YAMLS[$index]}
+    fi
+  
+    ${HPC_STACK_ROOT}/build_stack.sh -p $PREFIX -c $config -y $yaml -m
+done

--- a/setup_modules.sh
+++ b/setup_modules.sh
@@ -28,8 +28,9 @@ usage() {
   echo
   echo "Usage: $0 -p <prefix> | -c <config> | -h"
   echo
-  echo "  -p  installation prefix <prefix>    DEFAULT: $HOME/opt"
-  echo "  -c  use configuration file <config> DEFAULT: config/config_custom.sh"
+  echo "  -p  installation prefix <prefix>     DEFAULT: $HOME/opt"
+  echo "  -c  use configuration file <config>  DEFAULT: config/config_custom.sh"
+  echo "  -O  overwrite modules without prompt DEFAULT: NO"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -42,14 +43,21 @@ usage() {
 # Defaults:
 PREFIX="$HOME/opt"
 config="${HPC_STACK_ROOT}/config/config_custom.sh"
+checkOverwrite=true
 
-while getopts ":p:c:h" opt; do
+while getopts ":p:c:Oh" opt; do
   case $opt in
     p)
       PREFIX=$OPTARG
       ;;
     c)
       config=$OPTARG
+      ;;
+    O)
+      checkOverwrite=false
+      overwriteStackModulefile=YES
+      overwriteMPIModulefile=YES
+      overwriteCompilerModulefile=YES
       ;;
     h|\?|:)
       usage
@@ -93,82 +101,86 @@ $SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$
 
 $SUDO mkdir -p $PREFIX/modulefiles/stack/hpc
 
-#===============================================================================
-# Are the hpc-$compilerName.lua, hpc-$mpiName.lua or hpc/stack.lua modulefiles present at $PREFIX?
-# If yes, query the user to ask to over-write
-if [[ -f $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua ]]; then
-  echo "WARNING: $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua exists!"
-  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
-  read response
-else
-  response="YES"
-fi
-[[ $response =~ [yYtT] ]] && overwriteCompilerModulefile=YES
-unset response
 
-if [[ -f $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua ]]; then
-  echo "WARNING: $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua exists!"
-  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
-  read response
-else
-  response="YES"
-fi
-[[ $response =~ [yYtT] ]] && overwriteMPIModulefile=YES
-unset response
+if [[ "$checkOverwrite" == "true" ]]; then
+  #===============================================================================
+  # Are the hpc-$compilerName.lua, hpc-$mpiName.lua or hpc/stack.lua modulefiles present at $PREFIX?
+  # If yes, query the user to ask to over-write
+  if [[ -f $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua ]]; then
+      echo "WARNING: $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua exists!"
+      echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+      read response
+  else
+      response="YES"
+  fi
+  [[ $response =~ [yYtT] ]] && overwriteCompilerModulefile=YES
+  unset response
 
-if [[ -f $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua ]]; then
-  echo "WARNING: $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua exists!"
-  echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
-  read response
-else
-  response="YES"
+  if [[ -f $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua ]]; then
+      echo "WARNING: $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua exists!"
+      echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+      read response
+  else
+      response="YES"
+  fi
+  [[ $response =~ [yYtT] ]] && overwriteMPIModulefile=YES
+  unset response
+
+  # Command line argument -O(verwrite) overrides this check
+  if [[ -f $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua ]]; then
+      echo "WARNING: $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua exists!"
+      echo "Do you wish to over-write? [yes|YES|no|NO]: (DEFAULT: NO)  "
+      read response
+  else
+      response="YES"
+  fi
+  [[ $response =~ [yYtT] ]] && overwriteStackModulefile=YES
+  unset response
 fi
-[[ $response =~ [yYtT] ]] && overwriteStackModulefile=YES
-unset response
 
 #===============================================================================
 # Query the user if using native compiler and MPI, if overwriting (or writing for first time)
 if [[ ${overwriteCompilerModulefile:-} =~ [yYtT] ]]; then
-  $SUDO cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
-           $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
-  echo "Are you using native compiler $compilerName [yes|YES|no|NO]: (DEFAULT: NO)  "
-  read response
-  if [[ $response =~ [yYtT] ]]; then
-    echo -e "==========================\n USING NATIVE COMPILER"
-    cd $PREFIX/modulefiles/core/hpc-$compilerName
-    $SUDO sed -i -e '/load(compiler)/d' $compilerVersion.lua
-    $SUDO sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
-    [[ -f $compilerVersion.lua-e ]] && $SUDO rm -f "$compilerVersion.lua-e" # Stupid macOS does not understand -i, and creates a backup with -e (-e is the next sed option)
-    echo
-  fi
-  unset response
+    $SUDO cp $HPC_STACK_ROOT/modulefiles/core/hpc-$compilerName/hpc-$compilerName.lua \
+          $PREFIX/modulefiles/core/hpc-$compilerName/$compilerVersion.lua
+    echo "Are you using native compiler $compilerName [yes|YES|no|NO]: (DEFAULT: NO)  "
+    read response
+    if [[ $response =~ [yYtT] ]]; then
+        echo -e "==========================\n USING NATIVE COMPILER"
+        cd $PREFIX/modulefiles/core/hpc-$compilerName
+        $SUDO sed -i -e '/load(compiler)/d' $compilerVersion.lua
+        $SUDO sed -i -e '/prereq(compiler)/d' $compilerVersion.lua
+        [[ -f $compilerVersion.lua-e ]] && $SUDO rm -f "$compilerVersion.lua-e" # Stupid macOS does not understand -i, and creates a backup with -e (-e is the next sed option)
+        echo
+    fi
+    unset response
 fi
 
 if [[ ${overwriteMPIModulefile:-} =~ [yYtT] ]]; then
-  $SUDO cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
-           $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
-  echo "Are you using native MPI $mpiName [yes|YES|no|NO]: (DEFAULT: NO)  "
-  read response
-  if [[ $response =~ [yYtT] ]]; then
-    echo -e "===========================\n USING NATIVE MPI"
-    cd $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
-    $SUDO sed -i -e '/load(mpi)/d' $mpiVersion.lua
-    $SUDO sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
-    [[ -f $mpiVersion.lua-e ]] && $SUDO rm -f "$mpiVersion.lua-e"
-    echo
-  fi
-  unset response
+    $SUDO cp $HPC_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/hpc-$mpiName/hpc-$mpiName.lua \
+          $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName/$mpiVersion.lua
+    echo "Are you using native MPI $mpiName [yes|YES|no|NO]: (DEFAULT: NO)  "
+    read response
+    if [[ $response =~ [yYtT] ]]; then
+        echo -e "===========================\n USING NATIVE MPI"
+        cd $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion/hpc-$mpiName
+        $SUDO sed -i -e '/load(mpi)/d' $mpiVersion.lua
+        $SUDO sed -i -e '/prereq(mpi)/d' $mpiVersion.lua
+        [[ -f $mpiVersion.lua-e ]] && $SUDO rm -f "$mpiVersion.lua-e"
+        echo
+    fi
+    unset response
 fi
 
 if [[ ${overwriteStackModulefile:-} =~ [yYtT] ]]; then
-  $SUDO cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
-           $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
-  # Replace #PREFIX# from template with $PREFIX,
-  # sed does not like delimiter (/) to be a part of replacement string, do magic!
-  cd $PREFIX/modulefiles/stack/hpc
-  repl=$(echo ${PREFIX} | sed -e "s#/#\\\/#g")
-  $SUDO sed -i -e "s/#HPC_OPT#/${repl}/g" $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
-  [[ -f $HPC_STACK_VERSION.lua-e ]] && $SUDO rm -f "$HPC_STACK_VERSION.lua-e"
+    $SUDO cp $HPC_STACK_ROOT/modulefiles/stack/hpc/hpc.lua \
+          $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+    # Replace #PREFIX# from template with $PREFIX,
+    # sed does not like delimiter (/) to be a part of replacement string, do magic!
+    cd $PREFIX/modulefiles/stack/hpc
+    repl=$(echo ${PREFIX} | sed -e "s#/#\\\/#g")
+    $SUDO sed -i -e "s/#HPC_OPT#/${repl}/g" $PREFIX/modulefiles/stack/hpc/$HPC_STACK_VERSION.lua
+    [[ -f $HPC_STACK_VERSION.lua-e ]] && $SUDO rm -f "$HPC_STACK_VERSION.lua-e"
 fi
 
 #===============================================================================


### PR DESCRIPTION
I took @aerorahul's suggestion and modified the way I built multiple compiler/MPI combinations.

`loop_stack.sh` looks for `HPC_COMPILERS` and `HPC_MPIS` bash arrays to be set in the given config file and then loops over them.

Add these lines to the config file:
```
HPC_COMPILERS=("gnu/9.3.0" "intel/2020.1")
HPC_MPIS=("openmpi/4.0.1" "mpich/3.3.1")

# Optionally set HPC_YAMLS if you want to use a different yaml for each combination
#HPC_YAMLS=("stack_noaa.yaml" "stack_custom.yaml")
```

To build:
```
./loop_stack.sh -c config/config_custom.sh -y config/stack_custom.sh -p <prefix>
```

Using `loop_stack.sh` always uses modules. Multiple combinations cannot be built in a flat structure.

The same yaml file can be used for all `HPC_COMPILERS` by passing `-y` to `loop_stack.sh`, or `HPC_YAMLS` can be set in the config file as an array to use a different stack for each one. For example, you might want to build MPI with GNU, but not with Intel.

Add a `-O` (overwrite)  option to `setup_modules.sh` to disable asking whether to overwrite modules because calling `setup_modules.sh` twice will create two `hpc` modules and it eases automation.