### PR TITLE
Cron CI improvements

### DIFF
--- a/cron-ci/build-hpc-stack.sh
+++ b/cron-ci/build-hpc-stack.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -l
-# pass -l (treat script as login shell) so lmod module environment is picked up
+#!/bin/bash
+
 set -eux
 
 rm -rf ${HPC_INSTALL_PATH}/*

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -62,21 +62,21 @@ if [[ -f "${HPC_HOMEDIR}/prev_hash.txt" ]]; then
 fi
 
 echo `date`
+echo "Machine ID: ${HPC_MACHINE_ID}"
 echo ""
 echo "building hpc-stack..."
+echo ""
+echo "hpc-stack hash: ${current_hash}"
+echo "hpc-stack log: ${hpc_log}"
+echo ""
+
 ./cron-ci/build-hpc-stack.sh >> ${hpc_log} 2>&1
 
 # check if hpc-stack build succeded 
 if grep -qi "build_stack.sh: SUCCESS!" ${hpc_log}; then
     echo "hpc-stack build: PASS"
-    echo "hpc-stack hash: ${current_hash}"
-    echo "hpc-stack log: ${hpc_log}"
-    echo ""
 else
     echo "hpc-stack build: FAIL"
-    echo "hpc-stack hash: ${current_hash}"
-    echo "hpc-stack log: ${hpc_log}"
-    echo ""
     exit 1
 fi
 

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -20,7 +20,7 @@ export HPC_STACK_FILE=config/stack_noaa.yaml
 # set machine name (hera, jet, orion, etc) so script edits correct ufs modulefiles
 export HPC_MACHINE_ID=
 
-today=$(date +'%m-%d-%Y')
+today=$(date +'%Y-%m-%d')
 export HPC_LOG_PATH=${HPC_HOMEDIR}/logs/${today}
 
 # Run ufs-weather-model regression tests?
@@ -37,7 +37,7 @@ cd $HPC_DOWNLOAD_PATH
 rm -rf hpc-stack
 
 # mm-dd-yyy-hh:mm
-hpc_logdate=$(date +'%m-%d-%Y-%R')
+hpc_logdate=$(date +'%Y-%m-%d-%R')
 hpc_logname=hpc-stack_${hpc_logdate}.log
 hpc_log=${HPC_LOG_PATH}/${hpc_logname}
 

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -19,7 +19,9 @@ export HPC_STACK_FILE=config/stack_noaa.yaml
 
 # set machine name (hera, jet, orion, etc) so script edits correct ufs modulefiles
 export HPC_MACHINE_ID=
-export LOG_PATH=${HPC_HOMEDIR}/logs
+
+today=$(date +'%m-%d-%Y')
+export HPC_LOG_PATH=${HPC_HOMEDIR}/logs/${today}
 
 # Run ufs-weather-model regression tests?
 export TEST_UFS=true
@@ -27,7 +29,7 @@ export TEST_UFS=true
 # Create directories
 mkdir -p ${HPC_DOWNLOAD_PATH}
 mkdir -p ${HPC_HOMEDIR}
-mkdir -p ${LOG_PATH}
+mkdir -p ${HPC_LOG_PATH}
 
 cd $HPC_DOWNLOAD_PATH
 rm -rf hpc-stack
@@ -35,7 +37,7 @@ rm -rf hpc-stack
 # mm-dd-yyy-hh:mm
 hpc_logdate=$(date +'%m-%d-%Y-%R')
 hpc_logname=hpc-stack_${hpc_logdate}.log
-hpc_log=${LOG_PATH}/${hpc_logname}
+hpc_log=${HPC_LOG_PATH}/${hpc_logname}
 
 git clone https://github.com/NOAA-EMC/hpc-stack.git > /dev/null 2>&1
 cd hpc-stack

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -36,7 +36,7 @@ mkdir -p ${HPC_LOG_PATH}
 cd $HPC_DOWNLOAD_PATH
 rm -rf hpc-stack
 
-# mm-dd-yyy-hh:mm
+# yyyy-mm-dd-hh:mm
 hpc_logdate=$(date +'%Y-%m-%d-%R')
 hpc_logname=hpc-stack_${hpc_logdate}.log
 hpc_log=${HPC_LOG_PATH}/${hpc_logname}

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -25,7 +25,7 @@ export HPC_LOG_PATH=${HPC_HOMEDIR}/logs/${today}
 
 # Run ufs-weather-model regression tests?
 export TEST_UFS=true
-export UFS_RT_FLAGS="-f -e"
+export UFS_RT_FLAGS="-e"
 export RT_COMPILER=intel
 
 # Create directories

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -25,6 +25,8 @@ export HPC_LOG_PATH=${HPC_HOMEDIR}/logs/${today}
 
 # Run ufs-weather-model regression tests?
 export TEST_UFS=true
+export UFS_RT_FLAGS="-f -e"
+export RT_COMPILER=intel
 
 # Create directories
 mkdir -p ${HPC_DOWNLOAD_PATH}

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -66,8 +66,8 @@ echo "Machine ID: ${HPC_MACHINE_ID}"
 echo ""
 echo "building hpc-stack..."
 echo ""
-echo "hpc-stack hash: ${current_hash}"
 echo "hpc-stack log: ${hpc_log}"
+echo "hpc-stack hash: ${current_hash}"
 echo ""
 
 ./cron-ci/build-hpc-stack.sh >> ${hpc_log} 2>&1

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 set -eu
 
 cron_dir=${HPC_DOWNLOAD_PATH}/hpc-stack/cron-ci

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -8,7 +8,6 @@ if [[ "$TEST_UFS" == true ]]; then
     cd ${HPC_DOWNLOAD_PATH}
     rm -rf ufs-weather-model
 
-    # mm-dd-yyy-hh:mm
     ufs_logdate=$(date +'%Y-%m-%d-%R')
     ufs_logname=ufs_${ufs_logdate}.log
     ufs_log=${HPC_LOG_PATH}/${ufs_logname}

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -4,8 +4,30 @@ set -eu
 cron_dir=${HPC_DOWNLOAD_PATH}/hpc-stack/cron-ci
 
 if [[ "$TEST_UFS" == true ]]; then
+
+    cd ${HPC_DOWNLOAD_PATH}
+    rm -rf ufs-weather-model
+
+    # mm-dd-yyy-hh:mm
+    ufs_logdate=$(date +'%m-%d-%Y-%R')
+    ufs_logname=ufs_${ufs_logdate}.log
+    ufs_log=${HPC_LOG_PATH}/${ufs_logname}
+
+    git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log} 2>&1
+    cd ufs-weather-model
+
+    ufs_hash=$(git rev-parse HEAD)
+
+    echo ""
+    echo "testing ufs-weather-model..."
+    echo ""
+    echo "UFS log: ${ufs_log}"
+    echo "UFS hash: ${ufs_hash}"
+    echo ""
+
+    git submodule update --init --recursive >> ${ufs_log} 2>&1
     
-    ${cron_dir}/test-ufs.sh
+    ${cron_dir}/test-ufs.sh >> ${ufs_log} 2>&1
 
     # check if ufs regression tests were successful
     if grep -qi "REGRESSION TEST WAS SUCCESSFUL" ${ufs_log}; then

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -7,7 +7,7 @@ if [[ "$TEST_UFS" == true ]]; then
     # mm-dd-yyy-hh:mm
     ufs_logdate=$(date +'%m-%d-%Y-%R')
     ufs_logname=ufs_${ufs_logdate}.log
-    ufs_log=${LOG_PATH}/${ufs_logname}
+    ufs_log=${HPC_LOG_PATH}/${ufs_logname}
     
     echo ""
     echo "testing ufs-weather-model..."

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -8,9 +8,14 @@ if [[ "$TEST_UFS" == true ]]; then
     ufs_logdate=$(date +'%m-%d-%Y-%R')
     ufs_logname=ufs_${ufs_logdate}.log
     ufs_log=${HPC_LOG_PATH}/${ufs_logname}
-    
+
     echo ""
     echo "testing ufs-weather-model..."
+    echo ""
+    echo "UFS hash: ${ufs_hash}"
+    echo "UFS log: ${ufs_log}"
+    echo ""
+    
     ${cron_dir}/test-ufs.sh >> ${ufs_log} 2>&1
 
     ufs-hash=$(git -C ${HPC_DOWNLOAD_PATH}/ufs-weather-model rev-parse HEAD)
@@ -20,9 +25,5 @@ if [[ "$TEST_UFS" == true ]]; then
     else
         echo "UFS regression tests: FAIL"
     fi
-    # Output data
-    echo ""
-    echo "ufs hash: ${ufs_hash}"
-    echo "UFS log: ${ufs_log}"
 fi
 

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -4,21 +4,9 @@ set -eu
 cron_dir=${HPC_DOWNLOAD_PATH}/hpc-stack/cron-ci
 
 if [[ "$TEST_UFS" == true ]]; then
-    # mm-dd-yyy-hh:mm
-    ufs_logdate=$(date +'%m-%d-%Y-%R')
-    ufs_logname=ufs_${ufs_logdate}.log
-    ufs_log=${HPC_LOG_PATH}/${ufs_logname}
-
-    echo ""
-    echo "testing ufs-weather-model..."
-    echo ""
-    echo "UFS hash: ${ufs_hash}"
-    echo "UFS log: ${ufs_log}"
-    echo ""
     
-    ${cron_dir}/test-ufs.sh >> ${ufs_log} 2>&1
+    ${cron_dir}/test-ufs.sh
 
-    ufs-hash=$(git -C ${HPC_DOWNLOAD_PATH}/ufs-weather-model rev-parse HEAD)
     # check if ufs regression tests were successful
     if grep -qi "REGRESSION TEST WAS SUCCESSFUL" ${ufs_log}; then
         echo "UFS regression tests: PASS"

--- a/cron-ci/test-applications.sh
+++ b/cron-ci/test-applications.sh
@@ -9,7 +9,7 @@ if [[ "$TEST_UFS" == true ]]; then
     rm -rf ufs-weather-model
 
     # mm-dd-yyy-hh:mm
-    ufs_logdate=$(date +'%m-%d-%Y-%R')
+    ufs_logdate=$(date +'%Y-%m-%d-%R')
     ufs_logname=ufs_${ufs_logdate}.log
     ufs_log=${HPC_LOG_PATH}/${ufs_logname}
 

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
-set -eu
-
-cd ${HPC_DOWNLOAD_PATH}
-rm -rf ufs-weather-model
-
-# mm-dd-yyy-hh:mm
-ufs_logdate=$(date +'%m-%d-%Y-%R')
-ufs_logname=ufs_${ufs_logdate}.log
-ufs_log=${HPC_LOG_PATH}/${ufs_logname}
-
-git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log} 2>&1
-cd ufs-weather-model
-
-ufs_hash=$(git rev-parse HEAD)
-
-echo ""
-echo "testing ufs-weather-model..."
-echo ""
-echo "UFS log: ${ufs_log}"
-echo "UFS hash: ${ufs_hash}"
-echo ""
-
-git submodule update --init --recursive >> ${ufs_log} 2>&1
+set -eux
 
 # change module use to new hpc-stack location
 sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*
@@ -38,4 +16,4 @@ if [[ -f modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3_debug ]]; then
 fi
 
 cd tests
-./rt.sh ${UFS_RT_FLAGS} >> ${ufs_log} 2>&1
+./rt.sh ${UFS_RT_FLAGS}

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -9,7 +9,7 @@ ufs_logdate=$(date +'%m-%d-%Y-%R')
 ufs_logname=ufs_${ufs_logdate}.log
 ufs_log=${HPC_LOG_PATH}/${ufs_logname}
 
-git clone https://github.com/ufs-community/ufs-weather-model.git > >> ${ufs_log}
+git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log}
 cd ufs-weather-model
 
 ufs_hash=$(git -rev-parse HEAD)

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -24,18 +24,18 @@ echo ""
 git submodule update --init --recursive >> ${ufs_log}
 
 # change module use to new hpc-stack location
-sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.intel/*
+sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*
 
 # remove versions from hpc-stack libraries only (between module load hpc and end-of-file)
-sed -i "/module load hpc/,\$ s:module load \(.*\)/.*:module load \1:" modulefiles/${HPC_MACHINE_ID}.intel/*
+sed -i "/module load hpc/,\$ s:module load \(.*\)/.*:module load \1:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*
 
 # give version to ESMF because two versions are built
-sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/${HPC_MACHINE_ID}.intel/fv3
+sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3
 
 # check if fv3_debug exists. sed fails if it doesn't.
-if [[ -f modulefiles/${HPC_MACHINE_ID}.intel/fv3_debug ]]; then
-    sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/${HPC_MACHINE_ID}.intel/fv3_debug
+if [[ -f modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3_debug ]]; then
+    sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3_debug
 fi
 
 cd tests
-./rt.sh -f -e >> ${ufs_log} 2>&1
+./rt.sh ${UFS_RT_FLAGS} >> ${ufs_log} 2>&1

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -1,24 +1,41 @@
-#!/bin/bash -l
-set -eux
+#!/bin/bash
+set -eu
 
 cd ${HPC_DOWNLOAD_PATH}
 rm -rf ufs-weather-model
 
-git clone https://github.com/ufs-community/ufs-weather-model.git
+# mm-dd-yyy-hh:mm
+ufs_logdate=$(date +'%m-%d-%Y-%R')
+ufs_logname=ufs_${ufs_logdate}.log
+ufs_log=${HPC_LOG_PATH}/${ufs_logname}
+
+git clone https://github.com/ufs-community/ufs-weather-model.git > >> ${ufs_log}
 cd ufs-weather-model
-git submodule update --init --recursive
+
+ufs_hash=$(git -rev-parse HEAD)
+
+echo ""
+echo "testing ufs-weather-model..."
+echo ""
+echo "UFS log: ${ufs_log}"
+echo "UFS hash: ${ufs_hash}"
+echo ""
+
+git submodule update --init --recursive >> ${ufs_log}
 
 # change module use to new hpc-stack location
 sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.intel/*
 
-# remove version from module load
-sed -i "s:module load \(.*\)/.*:module load \1:" modulefiles/${HPC_MACHINE_ID}.intel/*
+# remove versions from hpc-stack libraries only (between module load hpc and end-of-file)
+sed -i "/module load hpc/,\$ s:module load \(.*\)/.*:module load \1:" modulefiles/${HPC_MACHINE_ID}.intel/*
 
 # give version to ESMF because two versions are built
 sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/${HPC_MACHINE_ID}.intel/fv3
-sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/${HPC_MACHINE_ID}.intel/fv3_debug
+
+# check if fv3_debug exists. sed fails if it doesn't.
+if [[ -f modulefiles/${HPC_MACHINE_ID}.intel/fv3_debug ]]; then
+    sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/${HPC_MACHINE_ID}.intel/fv3_debug
+fi
 
 cd tests
-./rt.sh -f -e
-
-
+./rt.sh -f -e >> ${ufs_log} 2>&1

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -9,7 +9,7 @@ ufs_logdate=$(date +'%m-%d-%Y-%R')
 ufs_logname=ufs_${ufs_logdate}.log
 ufs_log=${HPC_LOG_PATH}/${ufs_logname}
 
-git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log}
+git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log} 2>&1
 cd ufs-weather-model
 
 ufs_hash=$(git rev-parse HEAD)
@@ -21,7 +21,7 @@ echo "UFS log: ${ufs_log}"
 echo "UFS hash: ${ufs_hash}"
 echo ""
 
-git submodule update --init --recursive >> ${ufs_log}
+git submodule update --init --recursive >> ${ufs_log} 2>&1
 
 # change module use to new hpc-stack location
 sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -12,7 +12,7 @@ ufs_log=${HPC_LOG_PATH}/${ufs_logname}
 git clone https://github.com/ufs-community/ufs-weather-model.git >> ${ufs_log}
 cd ufs-weather-model
 
-ufs_hash=$(git -rev-parse HEAD)
+ufs_hash=$(git rev-parse HEAD)
 
 echo ""
 echo "testing ufs-weather-model..."


### PR DESCRIPTION
Add options to UFS regression tests. Their tests have been updated and the `-f` option was removed.

Use `RT_COMPILER` (intel/gnu) variable to select which UFS modules are edited to allow for building with GNU.

Remove `git -C` because it doesn't work on all versions of git.

Remove `-l` from scripts.

Group logs by day.




I've had this testing on Hera over the weekend.
