### PR TITLE
bugfix: compiler meta-module loads MKL module.

### DIFF
--- a/modulefiles/core/hpc-intel/hpc-intel.lua
+++ b/modulefiles/core/hpc-intel/hpc-intel.lua
@@ -13,7 +13,6 @@ conflict("hpc-gnu", "hpc-gcc")
 local compiler = pathJoin("intel",pkgVersion)
 load(compiler)
 prereq(compiler)
-try_load("mkl")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/compiler","intel",pkgVersion)

--- a/modulefiles/core/hpc-ips/hpc-ips.lua
+++ b/modulefiles/core/hpc-ips/hpc-ips.lua
@@ -14,7 +14,6 @@ conflict("hpc-intel")
 local compiler = pathJoin("ips",pkgVersion)
 load(compiler)
 prereq(compiler)
-try_load("mkl")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/compiler","ips",pkgVersion)


### PR DESCRIPTION
Issue #170 revealed on Orion that the `hpc-intel` meta-modulefile was also loading the `MKL` module file (in addition to the compiler).
On further examination, hpc-intel and hpc-ips modulefiles are trying to load mkl.
Loading MKL is not the job of these meta-modulefiles.  They should only load the relevant compiler module

closes #170 

This will most likely have an impact on the applications that load this modulefile.
The solution for these applications is to load the `mkl` module **after** `hpc-intel` or `hpc-ips` modulefile is loaded.  Unknowingly these applications were loading `mkl`, whether they were using it or not, depends on the application.  In the case of the GSI, it does use MKL.