### PR TITLE
Add pybind11 to hpc-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ script.
   - [Eigen](http://eigen.tuxfamily.org/)
   - [JSON for C++](https://github.com/nlohmann/json/)
   - [JSON Schema Validator for C++](https://github.com/pboettch/json-schema-validator)
+  - [pybind11](https://github.com/pybind/pybind11)
 
 * UFS Dependencies
   - [ESMF](https://www.earthsystemcog.org/projects/esmf/)

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -193,6 +193,7 @@ build_lib tau2
 build_lib cgal
 build_lib json
 build_lib json_schema_validator
+build_lib pybind11
 
 # JCSDA JEDI dependencies
 

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -253,6 +253,10 @@ json_schema_validator:
   build: YES
   version: 2.1.0
 
+pybind11:
+  build: YES
+  version: 2.5.0
+
 ecbuild:
   build: YES
   version: release-stable

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -250,6 +250,10 @@ json_schema_validator:
   build: NO
   version: 2.1.0
 
+pybind11:
+  build: YES
+  version: 2.5.0
+
 ecbuild:
   build: NO
   version: release-stable

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -251,6 +251,10 @@ json_schema_validator:
   build: YES
   version: 2.1.0
 
+pybind11:
+  build: YES
+  version: 2.5.0
+
 ecbuild:
   build: YES
   version: release-stable

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -254,6 +254,10 @@ json_schema_validator:
   build: YES
   version: 2.1.0
 
+pybind11:
+  build: YES
+  version: 2.5.0
+
 ecbuild:
   build: YES
   version: release-stable

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -250,6 +250,10 @@ json_schema_validator:
   build: YES
   version: 2.1.0
 
+pybind11:
+  build: YES
+  version: 2.5.0
+
 ecbuild:
   build: YES
   version: release-stable

--- a/libs/build_pybind11.sh
+++ b/libs/build_pybind11.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eux
+
+name="pybind11"
+version=${1:-${STACK_pybind11_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module try-load cmake
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+    if [[ -d $prefix ]]; then
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    fi
+else
+    prefix="/usr/local"
+fi
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+gitURL="https://github.com/pybind/pybind11"
+[[ -d $software ]] || ( git clone -b "v$version" $gitURL $software )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+[[ -d build ]] && rm -rf build
+mkdir -p build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+      -DPYBIND11_TEST=OFF \
+      -DCMAKE_VERBOSE_MAKEFILE=1 ..
+VERBOSE=$MAKE_VERBOSE $SUDO make -j${NTHREADS:-4} install
+
+# generate modulefile from template
+$MODULES && update_modules core $name $version \
+         || echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+

--- a/libs/build_pybind11.sh
+++ b/libs/build_pybind11.sh
@@ -21,7 +21,7 @@ if $MODULES; then
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 else
-    prefix="/usr/local"
+    prefix=${PYBIND11_ROOT:-"/usr/local"}
 fi
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}

--- a/modulefiles/core/pybind11/pybind11.lua
+++ b/modulefiles/core/pybind11/pybind11.lua
@@ -1,0 +1,22 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,"core",pkgName,pkgVersion)
+
+prepend_path("CPATH", pathJoin(base,"include"))
+
+setenv("pybind11_ROOT", base)
+setenv("pybind11_DIR", pathJoin(base,"share","cmake","pybind11"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Library")
+whatis("Description: pybind11 - Python C++ Interoperability Library")

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -25,9 +25,9 @@ function update_modules {
   esac
 
   [[ -e $tmpl_file ]] || ( echo "ERROR: $tmpl_file NOT FOUND! ABORT!"; exit 1 )
-  [[ -d $to_dir ]] || ( echo "ERROR: $mod_dir MODULE DIRECTORY NOT FOUND! ABORT!"; exit 1 )
+  [[ -d $to_dir ]] || ( mkdir -p $to_dir )
 
-  cd $to_dir
+  cd $to_dir || ( echo "ERROR: $to_dir MODULE DIRECTORY NOT FOUND! ABORT!"; exit 1 )
   $SUDO mkdir -p $name; cd $name
 
   if [[ $name != "cmake" || $name != "mpi" || $name != "gnu" ]]; then
@@ -56,7 +56,7 @@ EOF
   else
       $SUDO cp $tmpl_file $version.lua
   fi
-  
+
   # Make the latest installed version the default
   [[ -e default ]] && $SUDO rm -f default
   $SUDO ln -s $version.lua default
@@ -180,7 +180,7 @@ function build_lib() {
       [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
       ${HPC_STACK_ROOT}/libs/build_$1.sh 2>&1 | tee "$logdir/$1.log"
       local ret=${PIPESTATUS[0]}
-      if [[ $ret > 0 ]]; then
+      if [[ $ret -gt 0 ]]; then
           echo "BUILD FAIL!  Lib: $1 Error:$ret"
           [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
       fi
@@ -200,7 +200,7 @@ function build_nceplib() {
       [[ -f $logdir/$1.log ]] && ( logDate=$(date -r $logdir/$1.log +%F_%H%M); mv -f $logdir/$1.log $logdir/$1.log.$logDate )
       ${HPC_STACK_ROOT}/libs/build_nceplibs.sh "$1" 2>&1 | tee "$logdir/$1.log"
       local ret=${PIPESTATUS[0]}
-      if [[ $ret > 0 ]]; then
+      if [[ $ret -gt 0 ]]; then
           echo "BUILD FAIL!  NCEPlib: $1 Error:$ret"
           [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
       fi


### PR DESCRIPTION
This PR closes #180 

Adds `pybind11` to hpc-stack. Specifically:
* updated the README.md
* add `build_pybind11.sh`
* add modulefile
* update stack yamls

Fixes a bug in `stack_helpers.sh`. Specifically:
- `$mod_dir` is a variable no longer defined after the `update_modules` was updated 
- `>` is for string comparisons in bash.  use `-gt` for return code.