### PR TITLE
Update for building hpc-stack develop on Cheyenne

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -9,7 +9,7 @@ export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=Y
-export NTHREADS=8
+export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=N
 export   MAKE_CLEAN=N
@@ -17,5 +17,15 @@ export DOWNLOAD_ONLY=N
 export STACK_EXIT_ON_FAIL=Y
 export WGET="wget -nv"
 
+module purge
+module unuse /glade/u/apps/ch/modulefiles/default/compilers
+module use   /glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules/compilers
+export MODULEPATH_ROOT=/glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules
+
+module load gnu/9.1.0
+module load mpt/2.22
+module load ncarcompilers/0.5.0
+module load ncarenv/1.3
+
 # Load these basic modules for Cheyenne
-module load cmake/3.16.4
+module load cmake/3.18.2

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -9,7 +9,7 @@ export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=Y
-export NTHREADS=8
+export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=N
 export   MAKE_CLEAN=N
@@ -17,5 +17,15 @@ export DOWNLOAD_ONLY=N
 export STACK_EXIT_ON_FAIL=Y
 export WGET="wget -nv"
 
+module purge
+module unuse /glade/u/apps/ch/modulefiles/default/compilers
+module use   /glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules/compilers
+export MODULEPATH_ROOT=/glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules
+
+module load intel/19.1.1
+module load mpt/2.22
+module load ncarcompilers/0.5.0
+module load ncarenv/1.3
+
 # Load these basic modules for Cheyenne
-module load cmake/3.16.4
+module load cmake/3.18.2

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -61,7 +61,7 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: YES
+  build: NO
   version: 1.9.8
 
 pio:


### PR DESCRIPTION
See discussion in issue https://github.com/NOAA-EMC/hpc-stack/issues/155 - this PR does not yet update the GNU compiler from 9.1.0 to 10.1.0, but it solves the problems with conflicting modules installed by CISL and by hpc-stack.

With these changes, I can build hpc-stack develop successfully with both compilers GNU/9.1.0 and Intel/19.1.1.