### PR TITLE
Build FMS as part of the stack.

### DIFF
--- a/build_stack.sh
+++ b/build_stack.sh
@@ -145,62 +145,62 @@ build_lib jasper
 build_lib hdf5
 build_lib pnetcdf
 build_lib netcdf
-#build_lib nccmp
-#build_lib nco
-#build_lib cdo
-#build_lib pio
-#
-## UFS 3rd party dependencies
-#
-#build_lib esmf
+build_lib nccmp
+build_lib nco
+build_lib cdo
+build_lib pio
+
+# UFS 3rd party dependencies
+
+build_lib esmf
 build_lib fms
 
 # NCEPlibs
 
-#build_nceplib bacio
-#build_nceplib sigio
-#build_nceplib sfcio
-#build_nceplib gfsio
-#build_nceplib w3nco
-#build_nceplib sp
-#build_nceplib ip
-#build_nceplib ip2
-#build_nceplib landsfcutil
-#build_nceplib nemsio
-#build_nceplib nemsiogfs
-#build_nceplib w3emc
-#build_nceplib g2
-#build_nceplib g2c
-#build_nceplib g2tmpl
-#build_nceplib crtm
-#build_nceplib nceppost
-#build_nceplib upp
-#build_nceplib wrf_io
-#build_nceplib bufr
-#build_nceplib wgrib2
-#build_nceplib prod_util
-#build_nceplib grib_util
-#build_nceplib ncio
-#
-## JEDI 3rd party dependencies
-#
-#build_lib boost
-#build_lib eigen
-#build_lib gsl_lite
-#build_lib gptl
-#build_lib fftw
-#build_lib tau2
-#build_lib cgal
-#build_lib json
-#build_lib json_schema_validator
-#build_lib pybind11
-#
-## JCSDA JEDI dependencies
-#
-#build_lib ecbuild
-#build_lib eckit
-#build_lib fckit
-#build_lib atlas
+build_nceplib bacio
+build_nceplib sigio
+build_nceplib sfcio
+build_nceplib gfsio
+build_nceplib w3nco
+build_nceplib sp
+build_nceplib ip
+build_nceplib ip2
+build_nceplib landsfcutil
+build_nceplib nemsio
+build_nceplib nemsiogfs
+build_nceplib w3emc
+build_nceplib g2
+build_nceplib g2c
+build_nceplib g2tmpl
+build_nceplib crtm
+build_nceplib nceppost
+build_nceplib upp
+build_nceplib wrf_io
+build_nceplib bufr
+build_nceplib wgrib2
+build_nceplib prod_util
+build_nceplib grib_util
+build_nceplib ncio
+
+# JEDI 3rd party dependencies
+
+build_lib boost
+build_lib eigen
+build_lib gsl_lite
+build_lib gptl
+build_lib fftw
+build_lib tau2
+build_lib cgal
+build_lib json
+build_lib json_schema_validator
+build_lib pybind11
+
+# JCSDA JEDI dependencies
+
+build_lib ecbuild
+build_lib eckit
+build_lib fckit
+build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -145,62 +145,62 @@ build_lib jasper
 build_lib hdf5
 build_lib pnetcdf
 build_lib netcdf
-build_lib nccmp
-build_lib nco
-build_lib cdo
-build_lib pio
-
-# UFS 3rd party dependencies
-
-build_lib esmf
+#build_lib nccmp
+#build_lib nco
+#build_lib cdo
+#build_lib pio
+#
+## UFS 3rd party dependencies
+#
+#build_lib esmf
 build_lib fms
 
 # NCEPlibs
 
-build_nceplib bacio
-build_nceplib sigio
-build_nceplib sfcio
-build_nceplib gfsio
-build_nceplib w3nco
-build_nceplib sp
-build_nceplib ip
-build_nceplib ip2
-build_nceplib landsfcutil
-build_nceplib nemsio
-build_nceplib nemsiogfs
-build_nceplib w3emc
-build_nceplib g2
-build_nceplib g2c
-build_nceplib g2tmpl
-build_nceplib crtm
-build_nceplib nceppost
-build_nceplib upp
-build_nceplib wrf_io
-build_nceplib bufr
-build_nceplib wgrib2
-build_nceplib prod_util
-build_nceplib grib_util
-build_nceplib ncio
-
-# JEDI 3rd party dependencies
-
-build_lib boost
-build_lib eigen
-build_lib gsl_lite
-build_lib gptl
-build_lib fftw
-build_lib tau2
-build_lib cgal
-build_lib json
-build_lib json_schema_validator
-build_lib pybind11
-
-# JCSDA JEDI dependencies
-
-build_lib ecbuild
-build_lib eckit
-build_lib fckit
-build_lib atlas
+#build_nceplib bacio
+#build_nceplib sigio
+#build_nceplib sfcio
+#build_nceplib gfsio
+#build_nceplib w3nco
+#build_nceplib sp
+#build_nceplib ip
+#build_nceplib ip2
+#build_nceplib landsfcutil
+#build_nceplib nemsio
+#build_nceplib nemsiogfs
+#build_nceplib w3emc
+#build_nceplib g2
+#build_nceplib g2c
+#build_nceplib g2tmpl
+#build_nceplib crtm
+#build_nceplib nceppost
+#build_nceplib upp
+#build_nceplib wrf_io
+#build_nceplib bufr
+#build_nceplib wgrib2
+#build_nceplib prod_util
+#build_nceplib grib_util
+#build_nceplib ncio
+#
+## JEDI 3rd party dependencies
+#
+#build_lib boost
+#build_lib eigen
+#build_lib gsl_lite
+#build_lib gptl
+#build_lib fftw
+#build_lib tau2
+#build_lib cgal
+#build_lib json
+#build_lib json_schema_validator
+#build_lib pybind11
+#
+## JCSDA JEDI dependencies
+#
+#build_lib ecbuild
+#build_lib eckit
+#build_lib fckit
+#build_lib atlas
 
 # ==============================================================================
 # optionally clean up

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -82,7 +82,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -81,10 +81,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -79,7 +79,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -78,10 +78,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -80,9 +80,9 @@ esmf:
 
 fms:
   build: NO
-  version: master
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -80,7 +80,7 @@ esmf:
 
 fms:
   build: NO
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -83,7 +83,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -82,10 +82,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 
 bacio:
   build: YES

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -79,7 +79,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_ncar.yaml
+++ b/config/stack_ncar.yaml
@@ -78,10 +78,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -79,7 +79,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -78,10 +78,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -82,7 +82,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2020.04
+  version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -81,10 +81,10 @@ esmf:
   debug: NO
 
 fms:
-  build: NO
-  version: master
+  build: YES
+  version: 2020.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -DLARGEFILE=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
 bacio:
   build: YES

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -20,7 +20,7 @@ if $MODULES; then
   module list
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -48,14 +48,12 @@ mkdir -p build && cd build
 
 CMAKE_OPTS=${STACK_fms_cmake_opts:-""}
 
-cmake .. \
-      -DCMAKE_INSTALL_PREFIX=$prefix \
-      -D32BIT=ON -D64BIT=ON ${CMAKE_OPTS}
+cmake .. -DCMAKE_INSTALL_PREFIX=$prefix ${CMAKE_OPTS}
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 #[[ $MAKE_CHECK =~ [yYtT] ]] && make check # make check is not implemented in cmake builds
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
 # generate modulefile from template
-$MODULES && update_modules mpi $name $repo-$version \
+$MODULES && update_modules mpi $name $version \
          || echo $name $repo-$version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log


### PR DESCRIPTION
This PR:
- builds FMS as part of the stack
- Builds the tag 2020.04.03 used in the UFS weather model
- Provides both single (R4) and double (R8) precision libraries in the same installation