### PR TITLE
Feature/1.2.0 updates

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -4,8 +4,8 @@ gnu:
 
 mpi:
   build: NO
-  flavor: mpich
-  version: 3.4.1
+  flavor: openmpi
+  version: 4.0.1
 
 cmake:
   build: NO

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -4,8 +4,8 @@ gnu:
 
 mpi:
   build: NO
-  flavor: openmpi
-  version: 4.0.1
+  flavor: mpich
+  version: 3.4.1
 
 cmake:
   build: NO
@@ -75,7 +75,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_47
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -75,7 +75,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -169,12 +169,6 @@ crtm:
   version: v2.3.0
   install_as: 2.3.0
 
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
-
 upp:
   build: YES
   version: upp_v10.0.5

--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -69,7 +69,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -166,12 +166,6 @@ crtm:
   version: v2.3.0
   install_as: 2.3.0
 
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
-
 upp:
   build: YES
   version: upp_v10.0.5

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -72,7 +72,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_47
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -66,7 +66,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -72,7 +72,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -67,7 +67,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -73,7 +73,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -167,12 +167,6 @@ crtm:
   version: v2.3.0
   install_as: 2.3.0
 
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
-
 upp:
   build: YES
   version: upp_v10.0.5

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -73,7 +73,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_47
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -76,7 +76,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_21
+  version: 8_1_0_beta_snapshot_47
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -76,7 +76,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -170,12 +170,6 @@ crtm:
   version: v2.3.0
   install_as: 2.3.0
 
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
-
 upp:
   build: YES
   version: upp_v10.0.5

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -70,7 +70,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -72,7 +72,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_47
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -66,7 +66,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -2,11 +2,6 @@ cmake:
   build: NO
   version: 3.17.2
 
-mpi:
-  build: YES
-  flavor: mpich
-  version: 3.4.1
-
 jpeg:
   build: YES
   shared: NO

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -2,6 +2,11 @@ cmake:
   build: NO
   version: 3.17.2
 
+mpi:
+  build: YES
+  flavor: mpich
+  version: 3.4.1
+
 jpeg:
   build: YES
   shared: NO
@@ -165,12 +170,6 @@ crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
-
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
 
 upp:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -72,7 +72,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: NO
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -75,7 +75,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_27
+  version: 8_1_0_beta_snapshot_47
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -75,7 +75,7 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_0_beta_snapshot_47
+  version: 8_1_0
   shared: YES
   enable_pnetcdf: NO
   debug: NO

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -169,12 +169,6 @@ crtm:
   version: v2.3.0
   install_as: 2.3.0
 
-nceppost:
-  build: NO
-  version: dceca26
-  install_as: dceca26
-  openmp: ON
-
 upp:
   build: YES
   version: upp_v10.0.5

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -69,7 +69,7 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.2
+  version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 

--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -44,7 +44,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch --tags
+
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -34,7 +34,7 @@ if $MODULES; then
   fi
 else
   prefix=${CDO_ROOT:-"/usr/local"}
-  enable_pnetcdf=$(nc-config --has-pnetcdf)
+  [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] || enable_pnetcdf=$(nc-config --has-pnetcdf)
 fi
 
 if [[ ! -z $mpi ]]; then
@@ -53,24 +53,6 @@ export CXXFLAGS="${STACK_CXXFLAGS:-} ${STACK_cdo_CXXFLAGS:-} -fPIC"
 
 export F77=$FC
 export FCFLAGS=$FFLAGS
-
-HDF5_LDFLAGS="-L$HDF5_ROOT/lib"
-HDF5_LIBS="-lhdf5_hl -lhdf5"
-
-AM_LDFLAGS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
-EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
-
-if [[ ! -z $mpi ]]; then
-    if [[ $enable_pnetcdf =~ [yYtT] ]]; then
-	PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
-	PNETCDF_LIBS="-lpnetcdf"
-    fi
-fi
-NETCDF_LDFLAGS="-L$NETCDF_ROOT/lib"
-NETCDF_LIBS="-lnetcdf"
-
-export LDFLAGS="${PNETCDF_LDFLAGS:-} ${NETCDF_LDFLAGS:-} ${HDF5_LDFLAGS:-} ${AM_LDFLAGS:-}"
-export LIBS="${PNETCDF_LIBS:-} ${NETCDF_LIBS:-} ${HDF5_LIBS:-} ${EXTRA_LIBS:-}"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
@@ -99,6 +81,24 @@ software=$name-$version
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
+
+HDF5_LDFLAGS="-L$HDF5_ROOT/lib"
+HDF5_LIBS="-lhdf5_hl -lhdf5"
+
+AM_LDFLAGS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
+EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
+
+if [[ ! -z $mpi ]]; then
+    if [[ $enable_pnetcdf =~ [yYtT] ]]; then
+	PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
+	PNETCDF_LIBS="-lpnetcdf"
+    fi
+fi
+NETCDF_LDFLAGS="-L$NETCDF_ROOT/lib"
+NETCDF_LIBS="-lnetcdf"
+
+export LDFLAGS="${PNETCDF_LDFLAGS:-} ${NETCDF_LDFLAGS:-} ${HDF5_LDFLAGS:-} ${AM_LDFLAGS:-}"
+export LIBS="${PNETCDF_LIBS:-} ${NETCDF_LIBS:-} ${HDF5_LIBS:-} ${EXTRA_LIBS:-}"
 
 ../configure --prefix=$prefix \
              --with-hdf5=$HDF5_ROOT \

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -34,7 +34,6 @@ if $MODULES; then
   fi
 else
   prefix=${CDO_ROOT:-"/usr/local"}
-  [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] || enable_pnetcdf=$(nc-config --has-pnetcdf)
 fi
 
 if [[ ! -z $mpi ]]; then
@@ -87,6 +86,8 @@ HDF5_LIBS="-lhdf5_hl -lhdf5"
 
 AM_LDFLAGS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
 EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
+
+enable_pnetcdf=$(nc-config --has-pnetcdf)
 
 if [[ ! -z $mpi ]]; then
     if [[ $enable_pnetcdf =~ [yYtT] ]]; then

--- a/libs/build_ecbuild.sh
+++ b/libs/build_ecbuild.sh
@@ -27,7 +27,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch --tags
+
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -43,7 +43,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch --tags
+
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 sed -i -e 's/project( eckit CXX/project( eckit CXX Fortran/' CMakeLists.txt

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -70,11 +70,14 @@ URL="https://github.com/esmf-org/esmf"
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 software="ESMF_$version"
-# ESMF does not support out of source builds; clean out the clone
-[[ -d $software ]] && ( echo "$software exists, cleaning ..."; rm -rf $software )
+
 [[ -d $software ]] || ( git clone -b $software $URL $software )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+# ESMF does not support out of source builds; clean out the clone
+git reset --hard $software && git clean -fx
+
 export ESMF_DIR=$PWD
 
 # This is going to need a little work to adapt for various combinations

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -43,7 +43,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch --tags
+
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -41,7 +41,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch --tags
+
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -74,7 +74,7 @@ else
 fi
 
 make -j${NTHREADS:-4}
-[[ $MAKE_CHECK =~ [yYtT] ]] && make check
+[[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
 # generate modulefile from template

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -1,4 +1,4 @@
-fet!/bin/bash
+#!/bin/bash
 
 set -eux
 
@@ -52,38 +52,54 @@ if [[ "$version" = "2.5.1" ]]; then
 else
   branch=pio$(echo $version | sed -e 's/\./_/g')
 fi
-URL=" https://github.com/NCAR/ParallelIO"
-[[ -d $software ]] || git clone $URL $software
+[[ -f $software.tar.gz ]] || $WGET https://github.com/NCAR/ParallelIO/releases/download/$branch/${software}.tar.gz
+
+tar -xf ${software}.tar.gz
+
+
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git checkout $branch
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
-# These flags (e.g.) set the following that were used for HDF5 library:
-#LDFLAGS2='-L$ZLIB_ROOT/lib -L$SZIP_ROOT/lib'
-#LDFLAGS3=' -lsz -lz -ldl -lm '
-LDFLAGS2=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
-LDFLAGS3=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
-export LDFLAGS="$LDFLAGS2 $LDFLAGS3"
+# e.g. -L$ZLIB_ROOT/lib
+AM_LDFLAGS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2)
+# e.g. -lz -ldl -lm
+EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
 
-[[ $enable_pnetcdf =~ [yYtT] ]] && CMAKE_FLAGS+=" -DWITH_PNETCDF=ON -DPnetCDF_PATH=$PNETCDF" \
-                                || CMAKE_FLAGS+=" -DWITH_PNETCDF=OFF"
-[[ $enable_gptl =~ [yYtT] ]] && CMAKE_FLAGS+=" -DPIO_ENABLE_TIMING=ON" \
-                             || CMAKE_FLAGS+=" -DPIO_ENABLE_TIMING=OFF"
+export HDF5_LDFLAGS="-L$HDF5_ROOT/lib -lhdf5_hl -lhdf5"
+export HDF5_LIBS="-lhdf5_hl -lhdf5"
+export NETCDF_LDFLAGS="-L$NETCDF_ROOT/lib"
 
-cmake ..\
-  -DCMAKE_INSTALL_PREFIX=$prefix \
-  -DNetCDF_PATH=${NETCDF:-} \
-  -DHDF5_PATH=${HDF5_ROOT:-} \
-  -DCMAKE_VERBOSE_MAKEFILE=1 \
-  $CMAKE_FLAGS
+export CPPFLAGS="-I$NETCDF_ROOT/include"
+
+if [[ $enable_pnetcdf =~ [yYtT] ]]; then
+    PNETCDF_LDFLAGS="-L$PNETCDF_LIBRARIES"
+    PNETCDF_FLAGS=""
+else
+    PNETCDF_LDFLAGS=""
+    PNETCDF_FLAGS="--disable-pnetcdf"
+fi
+
+if [[ $enable_gptl =~ [yYtT] ]]; then
+    TIMING_FLAGS="--enable-timing"
+else
+    TIMING_FLAGS=""
+fi
+
+export LDFLAGS="$PNETCDF_LDFLAGS $NETCDF_LDFLAGS $HDF5_LDFLAGS $AM_LDFLAGS"
+export LIBS="$HDF5_LIBS $EXTRA_LIBS"
+
+../configure --prefix=$prefix \
+             --enable-fortran \
+             $TIMING_FLAGS $PNETCDF_FLAGS
+             
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
 # generate modulefile from template
-$MODULES && update_modules mpi $name $version
-echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules mpi $name $version \
+         || echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -101,5 +101,5 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
 # generate modulefile from template
-$MODULES && update_modules mpi $name $version \
-         || echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules mpi $name $version
+echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+fet!/bin/bash
 
 set -eux
 
@@ -55,7 +55,7 @@ fi
 URL=" https://github.com/NCAR/ParallelIO"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
-git fetch
+
 git checkout $branch
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && rm -rf build

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -52,7 +52,9 @@ if [[ "$version" = "2.5.1" ]]; then
 else
   branch=pio$(echo $version | sed -e 's/\./_/g')
 fi
-[[ -f $software.tar.gz ]] || $WGET https://github.com/NCAR/ParallelIO/releases/download/$branch/${software}.tar.gz
+
+URL="https://github.com/NCAR/ParallelIO/releases/download/$branch/${software}.tar.gz"
+[[ -f $software.tar.gz ]] || $WGET $URL
 
 tar -xf ${software}.tar.gz
 
@@ -102,4 +104,4 @@ VERBOSE=$MAKE_VERBOSE $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
-echo $name $version >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -52,7 +52,7 @@ cmake $sourceDir \
   $shared_flags
 
 make -j${NTHREADS:-4}
-[[ $MAKE_CHECK =~ [yYtT] ]] && make check
+[[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
 # generate modulefile from template


### PR DESCRIPTION
Fix DOWNLOAD_ONLY option by removing `git fetch`, using autotools build of PIO, and using `git reset --hard && git clean` to clean ESMF instead of re-downloading it.

Fix test options by swapping `make check` with `make test` for PNG and Jasper

Update ESMF to bs 47 which is what the weather model currently uses

Update PIO to 2.5.3 to fix a bug with `make check` 

Remove nceppost. I don't think this it is needed anymore.