### PR TITLE
Add boostrap option for CMake

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -8,8 +8,9 @@ mpi:
   version: 4.0.1
 
 cmake:
-  build: NO
-  version: 3.17.2
+  build: YES
+  bootstrap: YES
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -1,6 +1,7 @@
 cmake:
-  build: NO
-  version: 3.17.2
+  build: YES
+  bootstrap: NO
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -1,6 +1,7 @@
 cmake:
   build: YES
-  version: 3.17.2
+  bootstrap: NO
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -8,7 +8,7 @@ mpi:
   version: 3.3.1
 
 cmake:
-  build: YES
+  build: NO
   bootstrap: NO
   version: 3.20.1
 

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -8,8 +8,9 @@ mpi:
   version: 3.3.1
 
 cmake:
-  build: NO
-  version: 3.17.2
+  build: YES
+  bootstrap: NO
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -1,6 +1,7 @@
 cmake:
-  build: NO
-  version: 3.17.2
+  build: YES
+  bootstrap: NO
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -8,8 +8,9 @@ mpi:
   version: 4.0.1
 
 cmake:
-  build: NO
-  version: 3.17.2
+  build: YES
+  bootstrap: NO
+  version: 3.20.1
 
 jpeg:
   build: YES

--- a/libs/build_cmake.sh
+++ b/libs/build_cmake.sh
@@ -34,7 +34,13 @@ export CC=$SERIAL_CC
 export CXX=$SERIAL_CXX
 export FC=$SERIAL_FC
 
-$SUDO ./bootstrap --prefix=$prefix
+# CMake must be available if boostrap is set to no
+if [[ ${STACK_cmake_bootstrap:-} =~ [nNfF] ]]; then
+    cmake . -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE:STRING=Release
+else
+    $SUDO ./bootstrap --prefix=$prefix -- -DCMAKE_BUILD_TYPE:STRING=Release
+fi
+
 $SUDO make -j${NTHREADS:-4}
 $SUDO make install
 


### PR DESCRIPTION
Platforms with CMake already installed can disable bootstrap (boostrap: NO) and use the exisiting CMake to build the new CMake and save compile time.

Fixes #220 