### PR TITLE
Set FMS AVX2 flags for Cheyenne, patch FMS for GNU 9/10 on Cheyenne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.swp
 *~
 *.DS_Store
-*.patch
 *.diff
 *.tar.gz
 *.zip

--- a/config/config_cheyenne_gnu-10.sh
+++ b/config/config_cheyenne_gnu-10.sh
@@ -32,3 +32,11 @@ module load cmake/3.18.2
 
 # gfortran-10 compatibility flags for incompatible software
 export STACK_esmf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+export STACK_pnetcdf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+
+# Patch FMS
+export STACK_fms_PATCH="cheyenne_gnu_fms_mpp_util_mpi_inc.patch"

--- a/config/config_cheyenne_gnu-9.sh
+++ b/config/config_cheyenne_gnu-9.sh
@@ -29,3 +29,10 @@ module load ncarenv/1.3
 
 # Load these basic modules for Cheyenne
 module load cmake/3.18.2
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+
+# Patch FMS
+export STACK_fms_PATCH="cheyenne_gnu_fms_mpp_util_mpi_inc.patch"

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -29,3 +29,7 @@ module load ncarenv/1.3
 
 # Load these basic modules for Cheyenne
 module load cmake/3.18.2
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -44,6 +44,12 @@ URL="https://github.com/$repo/$name.git"
 
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+# Patch if requested
+if [[ ! -z "${STACK_fms_PATCH+x}" ]]; then
+  patch -p0 < ${HPC_STACK_ROOT}/patches/${STACK_fms_PATCH}
+fi
+
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build
 

--- a/patches/cheyenne_gnu_fms_mpp_util_mpi_inc.patch
+++ b/patches/cheyenne_gnu_fms_mpp_util_mpi_inc.patch
@@ -1,0 +1,12 @@
+--- mpp/include/mpp_util_mpi.inc	2021-02-08 08:24:21.000000000 -0700
++++ mpp/include/mpp_util_mpi.inc	2021-02-08 08:24:15.000000000 -0700
+@@ -169,7 +169,8 @@
+   integer, intent(in   ), optional :: msg_size(:)
+   integer, intent(in   ), optional :: msg_type(:)
+ 
+-  integer                       :: i, m, n, stride, my_check, rsize
++  integer                       :: i, m, n, stride, my_check
++  integer, volatile             :: rsize
+ 
+   if( debug .and. (current_clock.NE.0) )call SYSTEM_CLOCK(start_tick)
+   my_check = EVENT_SEND


### PR DESCRIPTION
Here is a suggestion to apply patches to packages that will work not just for FMS.

Also set the AVX2 flags for compiling FMS. Not sure if these should be the default in `libs/build_fms.sh` or not, therefore just adding to the Cheyenne configs for now.

Suggestions welcome. Whatever solution we adopt should make it into v1.2.0 in my opinion.