### PR TITLE
disable building cmake.

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -8,7 +8,7 @@ mpi:
   version: 4.0.1
 
 cmake:
-  build: YES
+  build: NO
   bootstrap: YES
   version: 3.20.1
 

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -1,5 +1,5 @@
 cmake:
-  build: YES
+  build: NO
   bootstrap: NO
   version: 3.20.1
 

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -1,5 +1,5 @@
 cmake:
-  build: YES
+  build: NO
   bootstrap: NO
   version: 3.20.1
 

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -1,5 +1,5 @@
 cmake:
-  build: YES
+  build: NO
   bootstrap: NO
   version: 3.20.1
 

--- a/config/stack_ufs_weather_ci.yaml
+++ b/config/stack_ufs_weather_ci.yaml
@@ -8,7 +8,7 @@ mpi:
   version: 4.0.1
 
 cmake:
-  build: YES
+  build: NO
   bootstrap: NO
   version: 3.20.1
 


### PR DESCRIPTION
cmake is and should be a system administrator provided tool.  We can handle its installation in the interim, but we should ask the sysadmins for an updated module ASAP.  This should not fall on the NCEPlibs team to provide, just like they don’t provide compilers and MPI.  

On generic machines such as linux and macOS, they can be installed via package managers.
The build script and capability is provided here for advanced users only.
General users have no business trying to build tools like cmake.