### PR TITLE
update versions of ecbuild, eckit, fckit and atlas

### DIFF
--- a/config/stack_custom.yaml
+++ b/config/stack_custom.yaml
@@ -256,23 +256,23 @@ pybind11:
 
 ecbuild:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.24.1
+  repo: ecmwf
 
 madis:
   build: YES

--- a/config/stack_gaea.yaml
+++ b/config/stack_gaea.yaml
@@ -246,25 +246,25 @@ json_schema_validator:
   version: 2.1.0
 
 pybind11:
-  build: YES
+  build: NO
   version: 2.5.0
 
 ecbuild:
   build: NO
-  version: release-stable
-  repo: jcsda
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
   build: NO
-  version: release-stable
-  repo: jcsda
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
   build: NO
-  version: release-stable
-  repo: jcsda
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
   build: NO
-  version: release-stable
-  repo: jcsda
+  version: 0.24.1
+  repo: ecmwf

--- a/config/stack_jedi.yaml
+++ b/config/stack_jedi.yaml
@@ -253,21 +253,20 @@ pybind11:
 
 ecbuild:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
   build: YES
-  version: release-stable
-  repo: jcsda
-
+  version: 0.24.1
+  repo: ecmwf

--- a/config/stack_mac.yaml
+++ b/config/stack_mac.yaml
@@ -256,23 +256,23 @@ pybind11:
 
 ecbuild:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.24.1
+  repo: ecmwf
 
 madis:
   build: YES

--- a/config/stack_noaa.yaml
+++ b/config/stack_noaa.yaml
@@ -251,23 +251,23 @@ pybind11:
 
 ecbuild:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
   build: YES
-  version: release-stable
-  repo: jcsda
+  version: 0.24.1
+  repo: ecmwf
 
 madis:
   build: YES


### PR DESCRIPTION
This PR updates the versions of JEDI dependency libraries.