### PR TITLE
Build python virtual environments.

### DIFF
--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -48,7 +48,7 @@ jobs:
         export HPC_COMPILER="${{ matrix.compiler }}/${gcc_ver}"
         export HPC_MPI="${{ matrix.mpi }}/${mpi_ver}"
         export HPC_PYTHON="python/${python_ver}"
-        ./build_stack.sh -p $prefix -c config/config_mac.sh -y config/stack_mac.yaml
+        ./build_stack.sh -p $prefix -c config/config_mac.sh -y stack/stack_mac.yaml
 
     - name: Upload logs
       if: ${{ always() }}

--- a/.github/workflows/build_ubuntu.yaml
+++ b/.github/workflows/build_ubuntu.yaml
@@ -50,7 +50,7 @@ jobs:
         export HPC_COMPILER="gnu/${gnu_ver}"
         export HPC_MPI="${{ matrix.mpi }}/${mpi_ver}"
         export HPC_PYTHON="python/${python_ver}"
-        ./build_stack.sh -p $prefix -c config/config_custom.sh -y config/stack_custom.yaml
+        ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_custom.yaml
 
     - name: Upload logs
       if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -174,10 +174,13 @@ script.
   - [EMC_post](https://github.com/noaa-emc/EMC_post.git)
 
 * JEDI Dependencies
-  - [ecbuild](https://github.com/jcsda/ecbuild.git)
-  - [eckit](https://github.com/jcsda/eckit.git)
-  - [fckit](https://github.com/jcsda/fckit.git)
-  - [atlas](https://github.com/jcsda/atlas.git)
+  - [ecbuild](https://github.com/ecmwf/ecbuild.git)
+  - [eckit](https://github.com/ecmwf/eckit.git)
+  - [fckit](https://github.com/ecmwf/fckit.git)
+  - [atlas](https://github.com/ecmwf/atlas.git)
+
+* Python Virtual Environments
+  - [r2d2](https://github.com/jcsda-internal/r2d2.git)
 
 **IMPORTANT: Steps 1, 2, and 3 need to be repeated for each
   compiler/MPI combination that you wish to install.** The new
@@ -303,9 +306,11 @@ template
 2. define a new section in the `yaml` file for that library/package in
 config directory
 
-3. Add a call to the new build script in `build_stack.sh`
+3. if the package is a python virtual environment, add a `requirements.txt` file listing the python packages required to install the package in `pyvenv/package_name.txt`
 
-4. Create a new module template at the appropriate place in the
+4. Add a call to the new build script in `build_stack.sh`
+
+5. Create a new module template at the appropriate place in the
 modulefiles directory, using exising files as a template
 
 ### Configuring for a new HPC

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ some of the parameter settings available.
 - **MAKE_VERBOSE:** Print out extra information to the log files during the build
 
 The next step is to choose what components of the stack you wish to
-build.  This is done by editing the file `config/stack_custom.yaml`
+build.  This is done by editing the file `stack/stack_custom.yaml`
 which defines the software packages to be built along with their
 version, options and compiler flags along with other package specific
 options.
@@ -270,7 +270,7 @@ default is to use `$HOME/opt` and `config/config_custom.sh`
 respectively.  `<yaml>` represents a user configurable yaml file
 containing a list of packages that need to be built in the stack along
 with their versions and package options. The default value of `<yaml>`
-is `config/stack_custom.yaml`.
+is `stack/stack_custom.yaml`.
 
 ## Additional Notes:
 

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -33,7 +33,7 @@ usage() {
 library=""
 export PREFIX="$HOME/opt"
 config="${HPC_STACK_ROOT}/config/config_custom.sh"
-yaml="${HPC_STACK_ROOT}/config/stack_custom.yaml"
+yaml="${HPC_STACK_ROOT}/stack/stack_custom.yaml"
 export MODULES=false
 
 while getopts ":p:c:y:l:mh" opt; do
@@ -151,11 +151,6 @@ build_lib nco
 build_lib cdo
 build_lib pio
 
-# UFS 3rd party dependencies
-
-build_lib esmf
-build_lib fms
-
 # NCEPlibs
 
 build_lib bacio
@@ -183,6 +178,14 @@ build_lib prod_util
 build_lib grib_util
 build_lib ncio
 
+# Other
+
+build_lib madis
+
+# Python virtual environments
+
+build_lib r2d2
+
 # JEDI 3rd party dependencies
 
 build_lib boost
@@ -196,15 +199,17 @@ build_lib json
 build_lib json_schema_validator
 build_lib pybind11
 
-# JCSDA JEDI dependencies
+# JEDI dependencies
 
 build_lib ecbuild
 build_lib eckit
 build_lib fckit
 build_lib atlas
 
-# Other
-build_lib madis
+# UFS 3rd party dependencies
+
+build_lib esmf
+build_lib fms
 
 # ==============================================================================
 # optionally clean up

--- a/config/config_mac.sh
+++ b/config/config_mac.sh
@@ -3,7 +3,7 @@
 # Compiler/MPI combination
 export HPC_COMPILER="clang/12.0.5"
 export HPC_MPI="mpich/3.3.2"
-export HPC_PYTHON="python/3.9.4"
+export HPC_PYTHON="python/3.9.5"
 
 # Build options
 export USE_SUDO=N

--- a/cron-ci/README.md
+++ b/cron-ci/README.md
@@ -23,12 +23,12 @@ Set these variables in `setup-cron.sh`
 
 * HPC_CONFIG - Custom config so compiler/MPI and other options can be set
 
-* HPC_STACK_FILE - The yaml file that specifies which libraries and versions to build. Default to config/stack_noaa.yaml
+* HPC_STACK_FILE - The yaml file that specifies which libraries and versions to build. Default to stack/stack_noaa.yaml
 
 * LOG_PATH - The path to write logs to. Defaults to HPC_HOMEDIR/logs.
 
 * HPC_MACHINE_ID - Name of machine (hera, orion, gaea, etc).
-This is used to edit the correct modules in ufs-weather-model/machine.compiler 
+This is used to edit the correct modules in ufs-weather-model/machine.compiler
 
 * TEST_UFS - Run ufs-weather-model regression tests. Defaults to true.
 

--- a/cron-ci/setup-cron.sh
+++ b/cron-ci/setup-cron.sh
@@ -15,7 +15,7 @@ export HPC_DOWNLOAD_PATH=
 # I put these in the HPC_HOMEDIR
 export HPC_CONFIG=${HPC_HOMEDIR}/
 # hpc-stack yaml file to build with, use stack_noaa by default
-export HPC_STACK_FILE=config/stack_noaa.yaml
+export HPC_STACK_FILE=stack/stack_noaa.yaml
 
 # set machine name (hera, jet, orion, etc) so script edits correct ufs modulefiles
 export HPC_MACHINE_ID=
@@ -74,7 +74,7 @@ echo ""
 
 ./cron-ci/build-hpc-stack.sh >> ${hpc_log} 2>&1
 
-# check if hpc-stack build succeded 
+# check if hpc-stack build succeded
 if grep -qi "build_stack.sh: SUCCESS!" ${hpc_log}; then
     echo "hpc-stack build: PASS"
 else

--- a/libs/build_pyvenv.sh
+++ b/libs/build_pyvenv.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -eux
+
+name=$1
+
+var="STACK_${name}_version"
+set +u
+stack_version=${!var}
+set -u
+version=${2:-$stack_version}
+
+var="STACK_${name}_requirements"
+set +u
+stack_rqmts=${!var}
+set -u
+rqmts=${stack_rqmts:-"requirements.txt"}
+
+python=$(echo $HPC_PYTHON | sed 's/\//-/g')
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_PYTHON
+  module list
+  set -x
+  prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  nameUpper=$(echo $name | tr [a-z] [A-Z])
+  eval prefix="\${${nameUpper}_ROOT:-'/usr/local'}"
+fi
+
+# Determine python version; 3.x
+python_version=$(python3 -c 'import sys;print(sys.version_info[0],".",sys.version_info[1],sep="")')
+
+# Support python version >= 3.6
+min_python_version=3.6
+if (( $(echo "$min_python_version >= $python_version" | bc -l) )); then
+  echo "Must have python version ($python_version) >= ${min_python_version}. ABORT!"
+  exit 1
+fi
+
+# Check for requirements file
+rqmts_file=${HPC_STACK_ROOT}/pyvenv/$rqmts
+[[ ! -f $rqmts_file ]] && ( echo "Unable to find requirements file: $rqmts \nABORT!"; exit 1 )
+
+# for python >= v3.9, upgrade dependencies (pip, setuptools) in place with '--upgrade-deps'
+upgrade_deps=""
+if (( $(echo "$python_version >= 3.9" | bc -l) )); then
+  upgrade_deps="--upgrade-deps"
+fi
+
+# Create a new virtual env.
+python3 -m venv $upgrade_deps $prefix
+
+# Activate newly created virtual env.
+set +x
+source $prefix/bin/activate
+set -x
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install packages from $rqmt_file
+pip install --no-cache-dir -r $rqmts_file
+
+# List installed packages
+pip list
+
+# generate modulefile from template
+$MODULES && update_modules python $name $version
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pyvenv.sh
+++ b/libs/build_pyvenv.sh
@@ -24,8 +24,7 @@ if $MODULES; then
   module load hpc-$HPC_PYTHON
   module list
   set -x
-  install_as=${name}_${version}
-  prefix="${PREFIX:-"/opt/modules"}/$python/$name/$install_as"
+  prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -56,7 +55,7 @@ if (( $(echo "$python_version >= 3.9" | bc -l) )); then
 fi
 
 # Create a new virtual env.
-python3 -m venv $upgrade_deps $prefix
+python3 -m venv --prompt $name $upgrade_deps $prefix
 
 # Activate newly created virtual env.
 set +x
@@ -73,5 +72,5 @@ pip install --no-cache-dir -r $rqmts_file
 pip list
 
 # generate modulefile from template
-$MODULES && update_modules python $name $install_as $python_version
+$MODULES && update_modules python $name $version $python_version
 echo $name $version $rqmts_file >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pyvenv.sh
+++ b/libs/build_pyvenv.sh
@@ -24,7 +24,8 @@ if $MODULES; then
   module load hpc-$HPC_PYTHON
   module list
   set -x
-  prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
+  install_as=${name}_${version}
+  prefix="${PREFIX:-"/opt/modules"}/$python/$name/$install_as"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -72,5 +73,5 @@ pip install --no-cache-dir -r $rqmts_file
 pip list
 
 # generate modulefile from template
-$MODULES && update_modules python $name $version
-echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules python $name $install_as $python_version
+echo $name $version $rqmts_file >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/modulefiles/core/hpc-cray-python/hpc-cray-python.lua
+++ b/modulefiles/core/hpc-cray-python/hpc-cray-python.lua
@@ -17,7 +17,7 @@ load(python)
 prereq(python)
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules" or "/opt"
-local mpath = pathJoin(opt,"modulefiles","cray-python",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/python","cray-python",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 whatis("Name: ".. pkgName)

--- a/modulefiles/core/hpc-miniconda3/hpc-miniconda3.lua
+++ b/modulefiles/core/hpc-miniconda3/hpc-miniconda3.lua
@@ -17,7 +17,7 @@ load(python)
 prereq(python)
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
-local mpath = pathJoin(opt,"modulefiles/core","miniconda3",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/python","miniconda3",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 whatis("Name: ".. pkgName)

--- a/modulefiles/core/hpc-python/hpc-python.lua
+++ b/modulefiles/core/hpc-python/hpc-python.lua
@@ -17,7 +17,7 @@ load(python)
 prereq(python)
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
-local mpath = pathJoin(opt,"modulefiles/core","python",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/python","python",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 whatis("Name: ".. pkgName)

--- a/modulefiles/python/pythonName/pythonVersion/r2d2/r2d2.lua
+++ b/modulefiles/python/pythonName/pythonVersion/r2d2/r2d2.lua
@@ -1,0 +1,36 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA          = hierarchyA(pkgNameVer,1)
+local pythonNameVer  = hierA[1]
+local pythonNameVerD = pythonNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,pythonNameVerD,pkgName,pkgVersion)
+
+-- activate on load, deactivate on unload
+if (mode() == "load") then
+  local source_cmd = "source " .. pathJoin(base, "bin/activate")
+  execute{cmd=source_cmd, modeA={"load"}}
+else
+  if (mode() == "unload") then
+    execute{cmd="deactivate", modeA={"unload"}}
+  end
+end
+
+-- The next 2 lines are automatically added (removed) by activate (deactivate)
+-- Hence, there is no need to add here.
+--prepend_path("PATH", pathJoin(base,"bin"))
+--prepend_path("PYTHONPATH", pathJoin(base,"lib/python@PYTHON_VERSION@/site-packages"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Software")
+whatis("Description: R2D2 Python Virtual Environment")

--- a/pyvenv/r2d2.txt
+++ b/pyvenv/r2d2.txt
@@ -1,0 +1,24 @@
+boto3 >= 1.16.38
+botocore >= 1.19.38
+cftime >= 1.3.0
+click >= 7.1.2
+Cython >= 0.29.21
+jmespath >= 0.10.0
+numpy >= 1.19.4
+pandas >= 1.1.5
+pip >= 20.3.3
+python-dateutil >= 2.8.1
+pytz >= 2020.4
+PyYAML >= 5.3.1
+s3transfer >= 0.3.3
+sdist >= 0.0.0
+six >= 1.15.0
+urllib3 >= 1.26.2
+wheel >= 0.36.2
+xarray >= 0.16.2
+
+netcdf4 >= 1.5.5.1 --prefer-binary
+h5netcdf >= 0.8.1 --prefer-binary
+h5py >= 3.1.0 --prefer-binary
+git+https://github.com/jcsda-internal/solo.git
+git+https://github.com/jcsda-internal/r2d2.git

--- a/setup_modules.sh
+++ b/setup_modules.sh
@@ -86,6 +86,7 @@ pythonVersion=$(echo $HPC_PYTHON | cut -d/ -f2)
 #===============================================================================
 # Deploy directory structure for modulefiles
 
+$SUDO mkdir -p $PREFIX/modulefiles/python
 $SUDO mkdir -p $PREFIX/modulefiles/core
 $SUDO mkdir -p $PREFIX/modulefiles/compiler/$compilerName/$compilerVersion
 $SUDO mkdir -p $PREFIX/modulefiles/mpi/$compilerName/$compilerVersion/$mpiName/$mpiVersion

--- a/stack/stack_comgsi.yaml
+++ b/stack/stack_comgsi.yaml
@@ -1,35 +1,26 @@
-gnu:
-  build: NO
-  version: 9.3.0
-
-mpi:
-  build: YES
-  flavor: mpich
-  version: 3.3.2
-
 cmake:
   build: NO
-  bootstrap: NO
+  bootstrap: YES
   version: 3.20.1
 
 jpeg:
-  build: YES
+  build: NO
   version: 9.1.0
 
 zlib:
-  build: YES
+  build: NO
   version: 1.2.11
 
 png:
-  build: YES
+  build: NO
   version: 1.6.35
 
 szip:
-  build: YES
+  build: NO
   version: 2.1.1
 
 jasper:
-  build: YES
+  build: NO
   version: 2.0.25
 
 udunits:
@@ -37,7 +28,7 @@ udunits:
   version: 2.2.28
 
 hdf5:
-  build: YES
+  build: NO
   version: 1.10.6
   shared: YES
   enable_szip: NO
@@ -49,231 +40,169 @@ pnetcdf:
   shared: YES
 
 netcdf:
-  build: YES
+  build: NO
   shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
-  disable_cxx: YES
 
 nccmp:
-  build: YES
-  version: 1.8.9.0
+  build: NO
+  version: 1.8.7.0
 
 nco:
   build: NO
   version: 4.9.3
 
 cdo:
-  build: YES
+  build: NO
   version: 1.9.8
-
-pio:
-  build: YES
-  version: 2.5.3
-  enable_pnetcdf: NO
-  enable_gptl: NO
-
-esmf:
-  build: YES
-  version: 8_1_1
-  shared: YES
-  enable_pnetcdf: NO
-  debug: NO
-
-fms:
-  build: YES
-  version: 2020.04.03
-  repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 
 bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.1
+  install_as: 3.4.1
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
-  build: YES
+  build: NO
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
-  python: YES
+  python: NO
+  is_nceplib: YES
 
 wgrib2:
-  build: YES
+  build: NO
   version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: OFF
+  openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
-  build: YES
+  build: NO
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
-  build: YES
+  build: NO
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
-  build: YES
+  build: NO
   version: develop
   install_as: 1.0.0
-
-boost:
-  build: YES
-  version: 1.68.0
-  level: headers-only
-
-eigen:
-  build: YES
-  version: 3.3.7
-
-gsl_lite:
-  build: YES
-  version: 0.37.0
-
-gptl:
-  build: NO
-  version: 8.0.2
-
-fftw:
-  build: NO
-  version: 3.3.8
-
-tau2:
-  build: NO
-  version: 3.25.1
-
-cgal:
-  build: NO
-  version: 5.0.2
-
-json:
-  build: YES
-  version: 3.9.1
-
-json_schema_validator:
-  build: YES
-  version: 2.1.0
-
-pybind11:
-  build: YES
-  version: 2.5.0
-
-ecbuild:
-  build: YES
-  version: 3.6.1
-  repo: ecmwf
-
-eckit:
-  build: YES
-  version: 1.16.0
-  repo: ecmwf
-
-fckit:
-  build: YES
-  version: 0.9.2
-  repo: ecmwf
-
-atlas:
-  build: YES
-  version: 0.24.1
-  repo: ecmwf
-
-madis:
-  build: YES
-  version: 4.3
+  is_nceplib: YES

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -302,7 +302,7 @@ madis:
   version: 4.3
 
 r2d2:
-  build: YES
+  build: NO
   version: 1.0.0
   requirements: r2d2.txt
   is_pyvenv: YES

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -1,36 +1,39 @@
+gnu:
+  build: NO
+  version: 9.3.0
+
+mpi:
+  build: NO
+  flavor: openmpi
+  version: 4.0.1
+
 cmake:
   build: NO
-  bootstrap: NO
+  bootstrap: YES
   version: 3.20.1
 
 jpeg:
   build: YES
-  shared: NO
   version: 9.1.0
 
 zlib:
   build: YES
-  shared: NO
   version: 1.2.11
 
 png:
   build: YES
-  shared: NO
   version: 1.6.35
 
 szip:
   build: YES
-  shared: NO
   version: 2.1.1
 
 jasper:
   build: YES
-  shared: NO
   version: 2.0.25
 
 udunits:
   build: YES
-  shared: NO
   version: 2.2.28
 
 hdf5:
@@ -43,16 +46,16 @@ hdf5:
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: NO
+  shared: YES
 
 netcdf:
   build: YES
   shared: YES
   enable_pnetcdf: NO
-  disable_cxx: NO
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
+  disable_cxx: YES
 
 nccmp:
   build: YES
@@ -75,12 +78,12 @@ pio:
 esmf:
   build: YES
   version: 8_1_1
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
-  build: NO
+  build: YES
   version: 2020.04.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
@@ -89,102 +92,121 @@ bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
   version: v3.4.2
   install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
   build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
   python: YES
+  is_nceplib: YES
 
 wgrib2:
   build: YES
@@ -193,22 +215,26 @@ wgrib2:
   openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
   build: YES
   version: develop
   install_as: 1.0.0
+  is_nceplib: YES
 
 boost:
   build: YES
@@ -270,3 +296,13 @@ atlas:
   build: YES
   version: 0.24.1
   repo: ecmwf
+
+madis:
+  build: YES
+  version: 4.3
+
+r2d2:
+  build: YES
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -1,12 +1,3 @@
-gnu:
-  build: NO
-  version: 9.3.0
-
-mpi:
-  build: NO
-  flavor: openmpi
-  version: 4.0.1
-
 cmake:
   build: NO
   bootstrap: NO
@@ -14,43 +5,49 @@ cmake:
 
 jpeg:
   build: YES
+  shared: NO
   version: 9.1.0
 
 zlib:
   build: YES
+  shared: NO
   version: 1.2.11
 
 png:
   build: YES
+  shared: NO
   version: 1.6.35
 
 szip:
   build: YES
+  shared: NO
   version: 2.1.1
 
 jasper:
   build: YES
+  shared: NO
   version: 2.0.25
 
 udunits:
   build: YES
+  shared: NO
   version: 2.2.28
 
 hdf5:
   build: YES
   version: 1.10.6
-  shared: YES
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: YES
+  shared: NO
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3
@@ -65,7 +62,7 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: NO
+  build: YES
   version: 1.9.8
 
 pio:
@@ -77,7 +74,7 @@ pio:
 esmf:
   build: YES
   version: 8_1_1
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   debug: NO
 
@@ -91,101 +88,121 @@ bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
   version: v3.4.2
   install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
   build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
 
 wgrib2:
   build: YES
@@ -194,19 +211,88 @@ wgrib2:
   openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
   build: YES
   version: develop
   install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: YES
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: NO
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: NO
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: YES
+  version: 4.3

--- a/stack/stack_jedi.yaml
+++ b/stack/stack_jedi.yaml
@@ -1,43 +1,40 @@
-gnu:
-  build: NO
-  version: 9.3.0
-
-mpi:
-  build: NO
-  flavor: openmpi
-  version: 4.0.1
-
 cmake:
   build: NO
-  bootstrap: YES
+  bootstrap: NO
   version: 3.20.1
 
 jpeg:
-  build: NO
+  build: YES
+  shared: NO
   version: 9.1.0
 
 zlib:
-  build: NO
+  build: YES
+  shared: NO
   version: 1.2.11
 
 png:
-  build: NO
+  build: YES
+  shared: NO
   version: 1.6.35
 
 szip:
-  build: NO
+  build: YES
+  shared: NO
   version: 2.1.1
 
 jasper:
-  build: NO
+  build: YES
+  shared: NO
   version: 2.0.25
 
 udunits:
-  build: NO
+  build: YES
+  shared: NO
   version: 2.2.28
 
 hdf5:
-  build: NO
+  build: YES
   version: 1.10.6
   shared: YES
   enable_szip: NO
@@ -46,38 +43,39 @@ hdf5:
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: YES
+  shared: NO
 
 netcdf:
-  build: NO
+  build: YES
   shared: YES
   enable_pnetcdf: NO
+  disable_cxx: NO
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
 
 nccmp:
-  build: NO
-  version: 1.8.7.0
+  build: YES
+  version: 1.8.9.0
 
 nco:
   build: NO
   version: 4.9.3
 
 cdo:
-  build: NO
+  build: YES
   version: 1.9.8
 
 pio:
-  build: NO
+  build: YES
   version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
-  build: NO
+  build: YES
   version: 8_1_1
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   debug: NO
 
@@ -91,137 +89,161 @@ bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
-  build: NO
+  build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
-  version: v3.4.1
-  install_as: 3.4.1
+  version: v3.4.2
+  install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
-  build: NO
+  build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
 
 wgrib2:
-  build: NO
+  build: YES
   version: v2.0.8-cmake-v6
   install_as: 2.0.8
   openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
-  build: NO
+  build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
-  build: NO
+  build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
-  build: NO
+  build: YES
   version: develop
   install_as: 1.0.0
+  is_nceplib: YES
 
 boost:
-  build: NO
+  build: YES
   version: 1.68.0
   level: headers-only
 
 eigen:
-  build: NO
+  build: YES
   version: 3.3.7
 
 gsl_lite:
-  build: NO
+  build: YES
   version: 0.37.0
 
 gptl:
@@ -241,37 +263,33 @@ cgal:
   version: 5.0.2
 
 json:
-  build: NO
+  build: YES
   version: 3.9.1
 
 json_schema_validator:
-  build: NO
+  build: YES
   version: 2.1.0
 
 pybind11:
-  build: NO
+  build: YES
   version: 2.5.0
 
 ecbuild:
-  build: NO
-  version: release-stable
-  repo: jcsda
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
 
 eckit:
-  build: NO
-  version: release-stable
-  repo: jcsda
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
 
 fckit:
-  build: NO
-  version: release-stable
-  repo: jcsda
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
 
 atlas:
-  build: NO
-  version: release-stable
-  repo: jcsda
-
-madis:
-  build: NO
-  version: 4.3
+  build: YES
+  version: 0.24.1
+  repo: ecmwf

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -1,3 +1,12 @@
+gnu:
+  build: NO
+  version: 9.3.0
+
+mpi:
+  build: YES
+  flavor: mpich
+  version: 3.3.2
+
 cmake:
   build: NO
   bootstrap: NO
@@ -5,53 +14,48 @@ cmake:
 
 jpeg:
   build: YES
-  shared: NO
   version: 9.1.0
 
 zlib:
   build: YES
-  shared: NO
   version: 1.2.11
 
 png:
   build: YES
-  shared: NO
   version: 1.6.35
 
 szip:
   build: YES
-  shared: NO
   version: 2.1.1
 
 jasper:
   build: YES
-  shared: NO
   version: 2.0.25
 
 udunits:
-  build: YES
-  shared: NO
+  build: NO
   version: 2.2.28
 
 hdf5:
   build: YES
   version: 1.10.6
-  shared: NO
+  shared: YES
   enable_szip: NO
   enable_zlib: YES
 
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: NO
+  shared: YES
 
 netcdf:
   build: YES
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
+  disable_cxx: YES
 
 nccmp:
   build: YES
@@ -74,7 +78,7 @@ pio:
 esmf:
   build: YES
   version: 8_1_1
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   debug: NO
 
@@ -82,132 +86,155 @@ fms:
   build: YES
   version: 2020.04.03
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 
 bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
   version: v3.4.2
   install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
   build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
-  python: NO
+  python: YES
+  is_nceplib: YES
 
 wgrib2:
   build: YES
   version: v2.0.8-cmake-v6
   install_as: 2.0.8
-  openmp: ON
+  openmp: OFF
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
   build: YES
   version: develop
   install_as: 1.0.0
+  is_nceplib: YES
 
 boost:
   build: YES
@@ -219,7 +246,7 @@ eigen:
   version: 3.3.7
 
 gsl_lite:
-  build: NO
+  build: YES
   version: 0.37.0
 
 gptl:
@@ -273,3 +300,9 @@ atlas:
 madis:
   build: YES
   version: 4.3
+
+r2d2:
+  build: YES
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -302,7 +302,7 @@ madis:
   version: 4.3
 
 r2d2:
-  build: YES
+  build: NO
   version: 1.0.0
   requirements: r2d2.txt
   is_pyvenv: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -88,102 +88,121 @@ bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
   version: v3.4.2
   install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
   build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
-  python: YES
+  python: NO
+  is_nceplib: YES
 
 wgrib2:
   build: YES
@@ -192,22 +211,26 @@ wgrib2:
   openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
   build: YES
   version: develop
   install_as: 1.0.0
+  is_nceplib: YES
 
 boost:
   build: YES
@@ -266,7 +289,7 @@ fckit:
   repo: ecmwf
 
 atlas:
-  build: NO
+  build: YES
   version: 0.24.1
   repo: ecmwf
 

--- a/stack/stack_ufs_weather_ci.yaml
+++ b/stack/stack_ufs_weather_ci.yaml
@@ -9,7 +9,7 @@ mpi:
 
 cmake:
   build: NO
-  bootstrap: YES
+  bootstrap: NO
   version: 3.20.1
 
 jpeg:
@@ -55,7 +55,6 @@ netcdf:
   version_c: 4.7.4
   version_f: 4.5.3
   version_cxx: 4.3.1
-  disable_cxx: YES
 
 nccmp:
   build: YES
@@ -66,7 +65,7 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: YES
+  build: NO
   version: 1.9.8
 
 pio:
@@ -92,102 +91,120 @@ bacio:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sigio:
   build: YES
   version: v2.3.2
   install_as: 2.3.2
+  is_nceplib: YES
 
 sfcio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 gfsio:
   build: YES
   version: v1.4.1
   install_as: 1.4.1
+  is_nceplib: YES
 
 w3nco:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 sp:
   build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip:
   build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
+  is_nceplib: YES
 
 ip2:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
+  is_nceplib: YES
 
 landsfcutil:
   build: YES
   version: v2.4.1
   install_as: 2.4.1
+  is_nceplib: YES
 
 nemsio:
   build: YES
   version: v2.5.2
   install_as: 2.5.2
+  is_nceplib: YES
 
 nemsiogfs:
   build: YES
   version: v2.5.3
   install_as: 2.5.3
+  is_nceplib: YES
 
 w3emc:
   build: YES
   version: v2.7.3
   install_as: 2.7.3
+  is_nceplib: YES
 
 g2:
   build: YES
   version: v3.4.2
   install_as: 3.4.2
+  is_nceplib: YES
 
 g2c:
   build: YES
   version: v1.6.2
   install_as: 1.6.2
+  is_nceplib: YES
 
 g2tmpl:
   build: YES
   version: v1.9.1
   install_as: 1.9.1
+  is_nceplib: YES
 
 crtm:
   build: YES
   version: v2.3.0
   install_as: 2.3.0
+  is_nceplib: YES
 
 upp:
   build: YES
   version: upp_v10.0.5
   install_as: 10.0.5
   openmp: ON
+  is_nceplib: YES
 
 wrf_io:
   build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
+  is_nceplib: YES
 
 bufr:
   build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
-  python: YES
+  is_nceplib: YES
 
 wgrib2:
   build: YES
@@ -196,84 +213,23 @@ wgrib2:
   openmp: ON
   spectral: ON
   ipolates: 3
+  is_nceplib: YES
 
 prod_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
+  is_nceplib: YES
 
 grib_util:
   build: YES
   version: v1.2.2
   install_as: 1.2.2
   openmp: ON
+  is_nceplib: YES
 
 ncio:
   build: YES
   version: develop
   install_as: 1.0.0
-
-boost:
-  build: YES
-  version: 1.68.0
-  level: headers-only
-
-eigen:
-  build: YES
-  version: 3.3.7
-
-gsl_lite:
-  build: YES
-  version: 0.37.0
-
-gptl:
-  build: NO
-  version: 8.0.2
-
-fftw:
-  build: NO
-  version: 3.3.8
-
-tau2:
-  build: NO
-  version: 3.25.1
-
-cgal:
-  build: NO
-  version: 5.0.2
-
-json:
-  build: YES
-  version: 3.9.1
-
-json_schema_validator:
-  build: YES
-  version: 2.1.0
-
-pybind11:
-  build: YES
-  version: 2.5.0
-
-ecbuild:
-  build: YES
-  version: 3.6.1
-  repo: ecmwf
-
-eckit:
-  build: YES
-  version: 1.16.0
-  repo: ecmwf
-
-fckit:
-  build: YES
-  version: 0.9.2
-  repo: ecmwf
-
-atlas:
-  build: YES
-  version: 0.24.1
-  repo: ecmwf
-
-madis:
-  build: YES
-  version: 4.3
+  is_nceplib: YES


### PR DESCRIPTION
This PR:

- adds ability to build python virtual environments and load them as modules.  This is a desired functionality for users of applications that require different combinations of python packages.
- This functionality is currently being exercised in JEDI related projects such as EWOK, JEDI-GDAS HofX applications.
- This functionality can be leveraged for other applications requiring python virtual environments e.g. JEDI-SOCA, MetPlus, etc.

To load a python virtual env. is the same as loading any other library or utility.  Loading the module will place the user in the python virtual env. (akin to `source venv/bin/activate`).  Unloading `deactivate`'s the virtual environment.

Also in this PR, 
- the yaml files have been moved to `stack/` from `config/`
- virtual environment `requirements.txt` files will be placed under `pyvenv/`
- Updates to `README.md` on how to add a virtual environment and correct paths for JEDI dependencies