### PR TITLE
Add libraries required to build UFS-Aerosols

### DIFF
--- a/.github/workflows/build_ubuntu.yaml
+++ b/.github/workflows/build_ubuntu.yaml
@@ -12,11 +12,26 @@ jobs:
 
     steps:
 
-    - name: Install dependencies (OpenMPI)
+    - name: cache-mpi
       if: matrix.mpi == 'openmpi'
+      id: cache-mpi
+      uses: actions/cache@v2
+      with:
+        path: ~/mpi
+        key: openmpi-4.1.1
+
+    - name: build-openmpi
+      if: steps.cache-mpi.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get update
-        sudo apt-get install openmpi-bin libopenmpi-dev
+        echo "$HOME/mpi/bin" >> $GITHUB_PATH
+        if [[ ${{ matrix.mpi }} == "openmpi" ]]; then
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz &> /dev/null
+          tar -xzf openmpi-4.1.1.tar.gz
+          cd openmpi-4.1.1
+          ./configure --prefix=$HOME/mpi --enable-mpi-fortran --enable-mpi-cxx
+          make -j2
+          make install
+        fi
 
     - name: Install dependencies (MPICH)
       if: matrix.mpi == 'mpich'

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -210,6 +210,11 @@ build_lib atlas
 
 build_lib esmf
 build_lib fms
+build_lib cmakemodules
+build_lib esma_cmake
+build_lib gftl_shared
+build_lib yafyaml
+build_lib mapl
 
 # ==============================================================================
 # optionally clean up

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eux
+
+name="cmakemodules"
+repo=${1:-${STACK_cmakemodules_repo:-"NOAA-EMC"}}
+version=${2:-${STACK_cmakemodules_version:-"develop"}}
+id=${version//\//-}
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$id"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+fi
+
+software=$name-$repo-$id
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+URL="https://github.com/$repo/$name.git"
+[[ -d $software ]] || git clone $URL $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+mkdir -p $prefix && cp -r $software/* $prefix
+
+# generate modulefile from template
+$MODULES && update_modules core $name $repo-$id
+echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -3,7 +3,7 @@
 set -eux
 
 name="cmakemodules"
-repo=${1:-${STACK_cmakemodules_repo:-"NOAA-EMC"}}
+repo="NOAA-EMC"
 version=${2:-${STACK_cmakemodules_version:-"develop"}}
 id=${version//\//-}
 
@@ -13,7 +13,7 @@ if $MODULES; then
   module list
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$id"
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -22,7 +22,7 @@ else
   prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
 fi
 
-software=$name-$repo-$id
+software=$name-$id
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
@@ -36,5 +36,5 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 mkdir -p $prefix && cp -r $software/* $prefix
 
 # generate modulefile from template
-$MODULES && update_modules core $name $repo-$id
-echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules core $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -19,7 +19,7 @@ if $MODULES; then
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
-  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+  prefix=${ESMA_CMAKE_ROOT:-"/usr/local"}
 fi
 
 software=$name-$repo-$id

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eux
+
+name="esma_cmake"
+repo=${1:-${STACK_esma_cmake_repo:-"GEOS-ESM"}}
+version=${2:-${STACK_esma_cmake_version:-"main"}}
+id=${version//\//-}
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$id"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+fi
+
+software=$name-$repo-$id
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+URL="https://github.com/$repo/$name.git"
+[[ -d $software ]] || git clone $URL $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+mkdir -p $prefix && cp -r $software/* $prefix
+
+# generate modulefile from template
+$MODULES && update_modules core $name $repo-$id
+echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -3,7 +3,7 @@
 set -eux
 
 name="esma_cmake"
-repo=${1:-${STACK_esma_cmake_repo:-"GEOS-ESM"}}
+repo="GEOS-ESM"
 version=${2:-${STACK_esma_cmake_version:-"main"}}
 id=${version//\//-}
 
@@ -13,7 +13,7 @@ if $MODULES; then
   module list
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$id"
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -22,7 +22,7 @@ else
   prefix=${ESMA_CMAKE_ROOT:-"/usr/local"}
 fi
 
-software=$name-$repo-$id
+software=$name-$id
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
@@ -36,5 +36,5 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 mkdir -p $prefix && cp -r $software/* $prefix
 
 # generate modulefile from template
-$MODULES && update_modules core $name $repo-$id
-echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules core $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -24,7 +24,7 @@ if $MODULES; then
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
-  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+  prefix=${GFTL_SHARED_ROOT:-"/usr/local"}
 fi
 
 software=$name-$repo-$id

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -3,7 +3,7 @@
 set -eux
 
 name="gftl-shared"
-repo=${1:-${STACK_gftl_shared_repo:-"Goddard-Fortran-Ecosystem"}}
+repo="Goddard-Fortran-Ecosystem"
 version=${2:-${STACK_gftl_shared_version:-"main"}}
 
 # Hyphenated version used for install prefix
@@ -18,7 +18,7 @@ if $MODULES; then
   module list
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$repo-$id"
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -27,7 +27,7 @@ else
   prefix=${GFTL_SHARED_ROOT:-"/usr/local"}
 fi
 
-software=$name-$repo-$id
+software=$name-$id
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
@@ -43,5 +43,5 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
 # generate modulefile from template
-$MODULES && update_modules compiler $name $repo-$id
-echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules compiler $name $id
+echo $name $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eux
+
+name="gftl-shared"
+repo=${1:-${STACK_gftl_shared_repo:-"Goddard-Fortran-Ecosystem"}}
+version=${2:-${STACK_gftl_shared_version:-"main"}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+id=${version//\//-}
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module try-load cmake
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$repo-$id"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+fi
+
+software=$name-$repo-$id
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+URL="https://github.com/$repo/$name.git"
+[[ -d $software ]] || git clone $URL $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $repo-$id
+echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -67,6 +67,7 @@ cmake .. \
       -DBUILD_WITH_PFLOGGER=OFF \
       -DESMA_USE_GFE_NAMESPACE=ON \
       -DBUILD_SHARED_MAPL=OFF \
+      -DNetCDF_Fortran_EXTRA_LIBRARIES="`nc-config --libs`" \
       ${CMAKE_OPTS}
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -37,6 +37,7 @@ if $MODULES; then
   fi
 else
   prefix=${MAPL_ROOT:-"/usr/local"}
+  export ESMFMKFILE=$ESMF_ROOT/lib/esmf.mk
 fi
 
 export FC=$MPI_FC

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -16,7 +16,6 @@ if $MODULES; then
   source $MODULESHOME/init/bash
   module load hpc-$HPC_COMPILER
   module load hpc-$HPC_MPI
-  module load hpc-$HPC_PYTHON
   module try-load cmake
   module load esma_cmake
   module load cmakemodules

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -eux
+
+name="mapl"
+repo=${1:-${STACK_mapl_repo:-"GEOS-ESM"}}
+version=${2:-${STACK_mapl_version:-"main"}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+mpi=$(echo $HPC_MPI | sed 's/\//-/g')
+id=${version//\//-}
+version_install=$repo-$id
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module load hpc-$HPC_PYTHON
+  module try-load cmake
+  module load esma_cmake
+  module load cmakemodules
+  module load ecbuild
+  module load gftl-shared
+  module load yafyaml
+  module load esmf
+  module load netcdf
+  module list
+
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version_install"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+fi
+
+if [[ ! -z $mpi ]]; then
+  export FC=$MPI_FC
+  export CC=$MPI_CC
+  export CXX=$MPI_CXX
+else
+  export FC=$SERIAL_FC
+  export CC=$SERIAL_CC
+  export CXX=$SERIAL_CXX
+fi
+
+software=$name-$version_install
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+URL="https://github.com/$repo/$name.git"
+[[ -d $software ]] || git clone $URL $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+
+CMAKE_OPTS=${STACK_mapl_cmake_opts:-""}
+
+cmake .. \
+      -DCMAKE_INSTALL_PREFIX=$prefix \
+      -DCMAKE_MODULE_PATH=$CMAKE_MODULE_PATH \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_WITH_FLAP=OFF \
+      -DBUILD_WITH_PFLOGGER=OFF \
+      -DESMA_USE_GFE_NAMESPACE=ON \
+      -DBUILD_SHARED_MAPL=OFF \
+      ${CMAKE_OPTS}
+
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
+
+# generate modulefile from template
+[[ -z $mpi ]] && modpath=compiler || modpath=mpi
+$MODULES && update_modules $modpath $name $version_install
+echo $name $version_install $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -3,14 +3,13 @@
 set -eux
 
 name="mapl"
-repo=${1:-${STACK_mapl_repo:-"GEOS-ESM"}}
+repo="GEOS-ESM"
 version=${2:-${STACK_mapl_version:-"main"}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 id=${version//\//-}
-version_install=$repo-$id
 
 if $MODULES; then
   set +x
@@ -32,7 +31,7 @@ if $MODULES; then
 
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version_install"
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -46,7 +45,7 @@ export FC=$MPI_FC
 export CC=$MPI_CC
 export CXX=$MPI_CXX
 
-software=$name-$version_install
+software=$name-$id
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
@@ -75,5 +74,5 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
 # generate modulefile from template
 modpath=mpi
-$MODULES && update_modules $modpath $name $version_install
-echo $name $version_install $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules $modpath $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -24,8 +24,8 @@ if $MODULES; then
   module load ecbuild
   module load gftl-shared
   module load yafyaml
-  module load esmf
   module load netcdf
+  module load esmf
   module list
 
   set -x
@@ -36,7 +36,7 @@ if $MODULES; then
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
-  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+  prefix=${MAPL_ROOT:-"/usr/local"}
 fi
 
 if [[ ! -z $mpi ]]; then

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -22,6 +22,8 @@ if $MODULES; then
   module load esma_cmake
   module load cmakemodules
   module load ecbuild
+  # module exports ecbuild_ROOT, but when building without modules ECBUILD_ROOT is set
+  export ECBUILD_ROOT=$ecbuild_ROOT
   module load gftl-shared
   module load yafyaml
   module load netcdf
@@ -61,13 +63,12 @@ CMAKE_OPTS=${STACK_mapl_cmake_opts:-""}
 
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
-      -DCMAKE_MODULE_PATH="${CMAKEMODULES_ROOT}/Modules;${ESMA_CMAKE_ROOT}" \
+      -DCMAKE_MODULE_PATH="${ESMA_CMAKE_ROOT};${CMAKEMODULES_ROOT}/Modules;${ECBUILD_ROOT}/share/ecbuild/cmake" \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_WITH_FLAP=OFF \
       -DBUILD_WITH_PFLOGGER=OFF \
       -DESMA_USE_GFE_NAMESPACE=ON \
       -DBUILD_SHARED_MAPL=OFF \
-      -DNetCDF_Fortran_EXTRA_LIBRARIES="`nc-config --libs`" \
       ${CMAKE_OPTS}
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -39,15 +39,9 @@ else
   prefix=${MAPL_ROOT:-"/usr/local"}
 fi
 
-if [[ ! -z $mpi ]]; then
-  export FC=$MPI_FC
-  export CC=$MPI_CC
-  export CXX=$MPI_CXX
-else
-  export FC=$SERIAL_FC
-  export CC=$SERIAL_CC
-  export CXX=$SERIAL_CXX
-fi
+export FC=$MPI_FC
+export CC=$MPI_CC
+export CXX=$MPI_CXX
 
 software=$name-$version_install
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
@@ -66,7 +60,7 @@ CMAKE_OPTS=${STACK_mapl_cmake_opts:-""}
 
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
-      -DCMAKE_MODULE_PATH=$CMAKE_MODULE_PATH \
+      -DCMAKE_MODULE_PATH="${CMAKEMODULES_ROOT}/Modules;${ESMA_CMAKE_ROOT}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_WITH_FLAP=OFF \
       -DBUILD_WITH_PFLOGGER=OFF \
@@ -77,6 +71,6 @@ cmake .. \
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
 # generate modulefile from template
-[[ -z $mpi ]] && modpath=compiler || modpath=mpi
+modpath=mpi
 $MODULES && update_modules $modpath $name $version_install
 echo $name $version_install $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -25,7 +25,7 @@ if $MODULES; then
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
 else
-  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+  prefix=${YAFYAML_ROOT:-"/usr/local"}
 fi
 
 software=$name-$repo-$id

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eux
+
+name="yafyaml"
+repo=${1:-${STACK_yafyaml_repo:-"Goddard-Fortran-Ecosystem"}}
+version=${2:-${STACK_yafyaml_version:-"main"}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+id=${version//\//-}
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module try-load cmake
+  module load gftl-shared
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$repo-$id"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
+else
+  prefix=${CMAKEMODULES_ROOT:-"/usr/local"}
+fi
+
+software=$name-$repo-$id
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+URL="https://github.com/$repo/$name.git"
+[[ -d $software ]] || git clone $URL $software
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+git fetch --tags
+git checkout $version
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ..
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $repo-$id
+echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -3,7 +3,7 @@
 set -eux
 
 name="yafyaml"
-repo=${1:-${STACK_yafyaml_repo:-"Goddard-Fortran-Ecosystem"}}
+repo="Goddard-Fortran-Ecosystem"
 version=${2:-${STACK_yafyaml_version:-"main"}}
 
 # Hyphenated version used for install prefix
@@ -19,7 +19,7 @@ if $MODULES; then
   module list
   set -x
 
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$repo-$id"
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
@@ -28,7 +28,7 @@ else
   prefix=${YAFYAML_ROOT:-"/usr/local"}
 fi
 
-software=$name-$repo-$id
+software=$name-$id
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
@@ -44,5 +44,5 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
 # generate modulefile from template
-$MODULES && update_modules compiler $name $repo-$id
-echo $name $repo-$id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules compiler $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/modulefiles/compiler/compilerName/compilerVersion/gftl-shared/gftl-shared.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/gftl-shared/gftl-shared.lua
@@ -1,0 +1,24 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+setenv("GFTL_SHARED_ROOT", base)
+setenv("GFTL_ROOT", base)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: gFTL-shared provides common gFTL containers of Fortran intrinsic types")

--- a/modulefiles/compiler/compilerName/compilerVersion/yafyaml/yafyaml.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/yafyaml/yafyaml.lua
@@ -1,0 +1,23 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+setenv("YAFYAML_ROOT", base)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: yet another Fortran (implementation of) YAML")

--- a/modulefiles/core/cmakemodules/cmakemodules.lua
+++ b/modulefiles/core/cmakemodules/cmakemodules.lua
@@ -1,0 +1,21 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,"core",pkgName,pkgVersion)
+
+prepend_path("CMAKE_MODULE_PATH", pathJoin(base,"Modules"), ";")
+
+setenv("cmakemodules_ROOT", base)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Software")
+whatis("Description: CMakeModules (A collection of ECMWF CMake modules)")

--- a/modulefiles/core/cmakemodules/cmakemodules.lua
+++ b/modulefiles/core/cmakemodules/cmakemodules.lua
@@ -11,11 +11,9 @@ local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 
-prepend_path("CMAKE_MODULE_PATH", pathJoin(base,"Modules"), ";")
-
-setenv("cmakemodules_ROOT", base)
+setenv("CMAKEMODULES_ROOT", base)
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: Software")
-whatis("Description: CMakeModules (A collection of ECMWF CMake modules)")
+whatis("Description: CMakeModules (A collection of CMake modules)")

--- a/modulefiles/core/esma_cmake/esma_cmake.lua
+++ b/modulefiles/core/esma_cmake/esma_cmake.lua
@@ -11,9 +11,7 @@ local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 
-prepend_path("CMAKE_MODULE_PATH", base, ";")
-
-setenv("esma_cmake_ROOT", base)
+setenv("ESMA_CMAKE_ROOT", base)
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/core/esma_cmake/esma_cmake.lua
+++ b/modulefiles/core/esma_cmake/esma_cmake.lua
@@ -1,0 +1,21 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,"core",pkgName,pkgVersion)
+
+prepend_path("CMAKE_MODULE_PATH", base, ";")
+
+setenv("esma_cmake_ROOT", base)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Software")
+whatis("Description: ESMA (NASA GEOS CMake configuration files)")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/mapl/mapl.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/mapl/mapl.lua
@@ -18,9 +18,6 @@ local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 
 setenv("MAPL_ROOT", base)
-prepend_path("CMAKE_MODULE_PATH", pathJoin(base, "share/MAPL/cmake"), ";")
-
-setenv("I_MPI_FABRICS", "shm:ofa")
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/mapl/mapl.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/mapl/mapl.lua
@@ -1,0 +1,28 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+setenv("MAPL_ROOT", base)
+prepend_path("CMAKE_MODULE_PATH", pathJoin(base, "share/MAPL/cmake"), ";")
+
+setenv("I_MPI_FABRICS", "shm:ofa")
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: MAPL is a foundation layer of the GEOS architecture")

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -39,7 +39,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: NO
+  shared: YES
   enable_szip: NO
   enable_zlib: YES
 
@@ -50,7 +50,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -306,3 +306,28 @@ r2d2:
   version: 1.0.0
   requirements: r2d2.txt
   is_pyvenv: YES
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: develop
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.0
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.7.1

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -39,7 +39,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: YES
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
@@ -50,7 +50,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -330,4 +330,4 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
-  version: v2.7.1
+  version: v2.7.2

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -315,7 +315,7 @@ esma_cmake:
 cmakemodules:
   build: YES
   repo: NOAA-EMC
-  version: develop
+  version: v1.2.0
 
 gftl_shared:
   build: YES

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -39,7 +39,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: NO
+  shared: YES
   enable_szip: NO
   enable_zlib: YES
 
@@ -50,7 +50,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -306,3 +306,28 @@ r2d2:
   version: 1.0.0
   requirements: r2d2.txt
   is_pyvenv: YES
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: develop
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.0
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.7.1

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -39,7 +39,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: YES
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
@@ -50,7 +50,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -330,4 +330,4 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
-  version: v2.7.1
+  version: v2.7.2

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -315,7 +315,7 @@ esma_cmake:
 cmakemodules:
   build: YES
   repo: NOAA-EMC
-  version: develop
+  version: v1.2.0
 
 gftl_shared:
   build: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -36,7 +36,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: YES
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
@@ -47,7 +47,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -320,4 +320,4 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
-  version: v2.7.1
+  version: v2.7.2

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -305,7 +305,7 @@ esma_cmake:
 cmakemodules:
   build: YES
   repo: NOAA-EMC
-  version: develop
+  version: v1.2.0
 
 gftl_shared:
   build: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -36,7 +36,7 @@ udunits:
 hdf5:
   build: YES
   version: 1.10.6
-  shared: NO
+  shared: YES
   enable_szip: NO
   enable_zlib: YES
 
@@ -47,7 +47,7 @@ pnetcdf:
 
 netcdf:
   build: YES
-  shared: NO
+  shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
   version_f: 4.5.3
@@ -296,3 +296,28 @@ atlas:
 madis:
   build: YES
   version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: develop
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.0
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.7.1


### PR DESCRIPTION
This PR adds a set of new libraries required to build the UFS aerosol component based on the NASA GOCART model.

Note that the following libraries are also added for convenience to create modules used to build MAPL. These libraries, however, are not required to build UFS-Aerosols.

- ESMA_cmake, v3.4.3
- CMakeModules