### PR TITLE
Correctly append OpenMPI to PATH if cached

### DIFF
--- a/.github/workflows/build_ubuntu.yaml
+++ b/.github/workflows/build_ubuntu.yaml
@@ -23,7 +23,6 @@ jobs:
     - name: build-openmpi
       if: steps.cache-mpi.outputs.cache-hit != 'true'
       run: |
-        echo "$HOME/mpi/bin" >> $GITHUB_PATH
         if [[ ${{ matrix.mpi }} == "openmpi" ]]; then
           wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz &> /dev/null
           tar -xzf openmpi-4.1.1.tar.gz
@@ -41,6 +40,9 @@ jobs:
 
     - name: Install dependencies
       run: |
+        if [[ ${{ matrix.mpi }} == "openmpi" ]]; then
+          echo "$HOME/mpi/bin" >> $GITHUB_PATH
+        fi
         sudo apt-get install python3-pip python3-dev python3-numpy
         sudo python3 -m pip install -U pip setuptools
         sudo python3 -m pip install -U numpy


### PR DESCRIPTION
OpenMPI was only being appended to PATH when being built, but if it were cached the build step is skipped and it wouldn't be available.