### PR TITLE
Remove CMAKE_PREFIX_PATH from yafyaml build

### DIFF
--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -40,7 +40,7 @@ git checkout $version
 
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH ..
+cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
 # generate modulefile from template


### PR DESCRIPTION
This variable is not needed. I get an unbound variable when building on Orion. 