### PR TITLE
Updates to python virtual env.

### DIFF
--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -3,7 +3,7 @@
 # Compiler/MPI combination
 export HPC_COMPILER="intel/18.0.5.274"
 export HPC_MPI="impi/2018.0.4"
-export HPC_PYTHON="intelpython/3.6.8"
+export HPC_PYTHON="miniconda3/4.5.12"
 
 # Build options
 export USE_SUDO=N
@@ -20,4 +20,5 @@ export WGET="wget -nv"
 
 # Load these basic modules for Hera
 module purge
-module load cmake/3.16.1
+module load cmake/3.20.1
+module use /contrib/miniconda3/modulefiles

--- a/modulefiles/python/pythonName/pythonVersion/pyvenv/pyvenv.lua
+++ b/modulefiles/python/pythonName/pythonVersion/pyvenv/pyvenv.lua
@@ -30,7 +30,7 @@ end
 --prepend_path("PATH", pathJoin(base,"bin"))
 --prepend_path("PYTHONPATH", pathJoin(base,"lib/python@PYTHON_VERSION@/site-packages"))
 
-whatis("Name: ".. pkgName)
+whatis("Name: " .. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: Software")
-whatis("Description: R2D2 Python Virtual Environment")
+whatis("Description: " .. pkgName .. " Python Virtual Environment")

--- a/pyvenv/hofx.txt
+++ b/pyvenv/hofx.txt
@@ -22,3 +22,4 @@ h5netcdf >= 0.8.1
 h5py >= 3.1.0
 git+https://github.com/jcsda-internal/solo.git
 git+https://github.com/jcsda-internal/r2d2.git
+git+https://github.com/noaa-emc/hofxcs.git

--- a/pyvenv/ufswm.txt
+++ b/pyvenv/ufswm.txt
@@ -1,0 +1,8 @@
+cftime >= 1.3.0
+Cython >= 0.29.21
+numpy >= 1.19.4
+pandas >= 1.1.5
+python-dateutil >= 2.8.1
+h5netcdf >= 0.8.1
+h5py >= 3.1.0
+netcdf4 >= 1.5.5.1

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -301,12 +301,6 @@ madis:
   build: YES
   version: 4.3
 
-r2d2:
-  build: NO
-  version: 1.0.0
-  requirements: r2d2.txt
-  is_pyvenv: YES
-
 esma_cmake:
   build: YES
   repo: GEOS-ESM
@@ -331,3 +325,15 @@ mapl:
   build: YES
   repo: GEOS-ESM
   version: v2.7.3
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  requirements: ufswm.txt
+  is_pyvenv: YES

--- a/stack/stack_jedi.yaml
+++ b/stack/stack_jedi.yaml
@@ -293,3 +293,9 @@ atlas:
   build: YES
   version: 0.24.1
   repo: ecmwf
+
+r2d2:
+  build: YES
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -301,12 +301,6 @@ madis:
   build: YES
   version: 4.3
 
-r2d2:
-  build: NO
-  version: 1.0.0
-  requirements: r2d2.txt
-  is_pyvenv: YES
-
 esma_cmake:
   build: YES
   repo: GEOS-ESM
@@ -331,3 +325,15 @@ mapl:
   build: YES
   repo: GEOS-ESM
   version: v2.7.3
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  requirements: ufswm.txt
+  is_pyvenv: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -296,3 +296,15 @@ atlas:
 madis:
   build: YES
   version: 4.3
+
+r2d2:
+  build: YES
+  version: 1.0.0
+  requirements: r2d2.txt
+  is_pyvenv: YES
+
+hofx:
+  build: YES
+  version: 1.0.0
+  requirements: hofx.txt
+  is_pyvenv: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -323,13 +323,19 @@ mapl:
   version: v2.7.3
 
 r2d2:
-  build: YES
+  build: NO
   version: 1.0.0
   requirements: r2d2.txt
   is_pyvenv: YES
 
 hofx:
-  build: YES
+  build: NO
   version: 1.0.0
   requirements: hofx.txt
+  is_pyvenv: YES
+
+ufswm:
+  build: YES
+  version: 1.0.0
+  requirements: ufswm.txt
   is_pyvenv: YES

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -8,7 +8,7 @@ function update_modules {
   local py_version=${4:-}
   case $modpath in
     python )
-      local tmpl_file=$HPC_STACK_ROOT/modulefiles/python/pythonName/pythonVersion/$name/$name.lua
+      local tmpl_file=$HPC_STACK_ROOT/modulefiles/python/pythonName/pythonVersion/pyvenv/pyvenv.lua
       local to_dir=$prefix/modulefiles/python/$HPC_PYTHON
       ;;
     core )


### PR DESCRIPTION
This PR:
* replaces `intelpython` with `miniconda3` on Hera for Python.
* updates `cmake` on Hera to 3.20.1
* improves `build_pyvenv.sh`
** provides ability to `DOWNLOAD_ONLY` for python package wheels.  The wheels should be downloaded on "similar" machines.  For e.g. downloading wheels on macOS for use on Linux OS will not work.
* generalizes how python virtual environment modules are created.
** do not need to create a modulefile for each individual python virtual environment.
* adds a recipe for python dependencies in the ufs-weather-model. 