### PR TITLE
Port hpc-stack to S4

### DIFF
--- a/config/config_s4.sh
+++ b/config/config_s4.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="intel/18.0.3"
+export HPC_MPI="impi/18.0.3"
+export HPC_PYTHON="miniconda/3.8-s4"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+
+# Load these basic modules for S4
+module purge
+module load license_intel/S4
+module load git/2.30.0

--- a/modulefiles/core/hpc-miniconda/hpc-miniconda.lua
+++ b/modulefiles/core/hpc-miniconda/hpc-miniconda.lua
@@ -1,0 +1,26 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+family("MetaPython")
+
+conflict(pkgName)
+conflict("hpc-python")
+conflict("hpc-intelpython")
+conflict("hpc-cray-python")
+
+local python = pathJoin("miniconda",pkgVersion)
+load(python)
+prereq(python)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/python","miniconda",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Python")
+whatis("Description: Miniconda3 Family and module access")


### PR DESCRIPTION
Added `config_s4.sh` and the new module file `hpc-miniconda.lua`, modeled after `hpc-miniconda3.lua`, to address #258.

The official install of hpc-stack on S4 is located on `/data/prod/hpc-stack` and can be accessed with `module use /data/prod/hpc-stack/modulefiles/stack`.

closes #258