### PR TITLE
Update configs

### DIFF
--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -22,3 +22,7 @@ export WGET="wget -nv"
 module purge
 module load cmake/3.20.1
 module use /contrib/miniconda3/modulefiles
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"

--- a/config/config_jet.sh
+++ b/config/config_jet.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="intel/18.0.5.274"
+export HPC_MPI="impi/2018.4.274"
+export HPC_PYTHON="intelpython/3.6.5"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=4
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+
+# Bypass unused variable bug in LMod version on Jet when sourcing the LMod setup
+export __lmod_vx=""
+
+module load make/3.20.1

--- a/config/config_orion.sh
+++ b/config/config_orion.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-#export HPC_COMPILER="intel/2019.5"
-#export HPC_MPI="impi/2019.6"
-#export HPC_COMPILER="intel/2018.4"
-#export HPC_MPI="impi/2018.4"
-export HPC_COMPILER="intel/2020"
-export HPC_MPI="impi/2020"
-#export HPC_COMPILER="gcc/8.3.0"
-#export HPC_MPI="openmpi/4.0.2"
+export HPC_COMPILER="intel/2018.4"
+export HPC_MPI="impi/2018.4"
 export HPC_PYTHON="python/3.7.5"
 
 # Build options
@@ -28,3 +22,7 @@ export WGET="wget -nv"
 module purge
 module load cmake
 module load git
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"

--- a/config/config_wcoss_dell_p3.sh
+++ b/config/config_wcoss_dell_p3.sh
@@ -28,3 +28,7 @@ module purge
 module load cmake/3.16.2
 module use -a /usrx/local/dev/modulefiles
 module load git/2.14.3
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -2,18 +2,13 @@
 set -eux
 
 # change module use to new hpc-stack location
-sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*
+sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:" modulefiles/ufs_${HPC_MACHINE_ID}.${RT_COMPILER}*
 
-# remove versions from hpc-stack libraries only (between module load hpc and end-of-file)
-sed -i "/module load hpc/,\$ s:module load \(.*\)/.*:module load \1:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/*
+# remove versions from hpc-stack libraries
+sed -i "s:module load \(.*\)/.*:module load \1:" modulefiles/ufs_common*
 
 # give version to ESMF because two versions are built
-sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3
-
-# check if fv3_debug exists. sed fails if it doesn't.
-if [[ -f modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3_debug ]]; then
-    sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/${HPC_MACHINE_ID}.${RT_COMPILER}/fv3_debug
-fi
+sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/ufs_common*
 
 cd tests
 ./rt.sh ${UFS_RT_FLAGS}

--- a/cron-ci/test-ufs.sh
+++ b/cron-ci/test-ufs.sh
@@ -8,7 +8,8 @@ sed -i "s:module use /.*/stack:module use ${HPC_INSTALL_PATH}/modulefiles/stack:
 sed -i "s:module load \(.*\)/.*:module load \1:" modulefiles/ufs_common*
 
 # give version to ESMF because two versions are built
-sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/ufs_common*
+sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}:" modulefiles/ufs_common
+sed -i "s:module load esmf:module load esmf/${STACK_esmf_version}-debug:" modulefiles/ufs_common_debug
 
 cd tests
 ./rt.sh ${UFS_RT_FLAGS}


### PR DESCRIPTION
Create a `config_jet.sh`

Update `config_orion.sh` to use correct compilers by default

Add vectorization flags to configs that are missing them.

Update the Cron testing job for the updated modulefile structure that the ufs weather model uses

Fix #271 #270 