### PR TITLE
Update versions for UPP, g2, and g2tmpl

### DIFF
--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.3
+  install_as: 3.4.3
   is_nceplib: YES
 
 g2c:
@@ -177,8 +177,8 @@ g2c:
 
 g2tmpl:
   build: YES
-  version: v1.9.1
-  install_as: 1.9.1
+  version: v1.10.0
+  install_as: 1.10.0
   is_nceplib: YES
 
 crtm:
@@ -189,8 +189,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.8
+  install_as: 10.0.8
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.3
+  install_as: 3.4.3
   is_nceplib: YES
 
 g2c:
@@ -177,8 +177,8 @@ g2c:
 
 g2tmpl:
   build: YES
-  version: v1.9.1
-  install_as: 1.9.1
+  version: v1.10.0
+  install_as: 1.10.0
   is_nceplib: YES
 
 crtm:
@@ -189,8 +189,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.8
+  install_as: 10.0.8
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -161,8 +161,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.3
+  install_as: 3.4.3
   is_nceplib: YES
 
 g2c:
@@ -173,8 +173,8 @@ g2c:
 
 g2tmpl:
   build: YES
-  version: v1.9.1
-  install_as: 1.9.1
+  version: v1.10.0
+  install_as: 1.10.0
   is_nceplib: YES
 
 crtm:
@@ -185,8 +185,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.8
+  install_as: 10.0.8
   openmp: ON
   is_nceplib: YES
 


### PR DESCRIPTION
Make the versions match what is used in the ufs-weather-model for UPP and g2tmpl.

And for g2 update for bugfix regarding re-used file units

Fix #274 