### PR TITLE
make the installation directory prefix and the modulefile readonly

### DIFF
--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -55,6 +55,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && ctest
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $repo-$version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_boost.sh
+++ b/libs/build_boost.sh
@@ -98,6 +98,9 @@ $SUDO mv stage/lib $prefix
 
 rm -f $HOME/user-config.jam
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -90,10 +90,10 @@ EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut 
 enable_pnetcdf=$(nc-config --has-pnetcdf)
 
 if [[ ! -z $mpi ]]; then
-    if [[ $enable_pnetcdf =~ [yYtT] ]]; then
-	PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
-	PNETCDF_LIBS="-lpnetcdf"
-    fi
+  if [[ $enable_pnetcdf =~ [yYtT] ]]; then
+    PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
+    PNETCDF_LIBS="-lpnetcdf"
+  fi
 fi
 NETCDF_LDFLAGS="-L$NETCDF_ROOT/lib"
 NETCDF_LIBS="-lnetcdf"
@@ -108,6 +108,9 @@ export LIBS="${PNETCDF_LIBS:-} ${NETCDF_LIBS:-} ${HDF5_LIBS:-} ${EXTRA_LIBS:-}"
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
+
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_cgal.sh
+++ b/libs/build_cgal.sh
@@ -52,6 +52,9 @@ URL="https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/$so
 cmake . -DCMAKE_INSTALL_PREFIX=$prefix
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_cmake.sh
+++ b/libs/build_cmake.sh
@@ -44,6 +44,9 @@ fi
 $SUDO make -j${NTHREADS:-4}
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -35,6 +35,9 @@ git checkout $version
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 mkdir -p $prefix && cp -r $software/* $prefix
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $id
 echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_condaenv.sh
+++ b/libs/build_condaenv.sh
@@ -79,6 +79,9 @@ echo "executing ... conda env list"
 conda env list
 set -x
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules python $name $version $python_version
 echo $name $version $rqmts_file >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_ecbuild.sh
+++ b/libs/build_ecbuild.sh
@@ -37,6 +37,9 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $repo-$version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -55,6 +55,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && ctest
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $repo-$version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_eigen.sh
+++ b/libs/build_eigen.sh
@@ -37,6 +37,9 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$prefix
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -35,6 +35,9 @@ git checkout $version
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 mkdir -p $prefix && cp -r $software/* $prefix
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $id
 echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -170,6 +170,9 @@ $SUDO make install
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 [[ $MAKE_CHECK =~ [yYtT] ]] && make installcheck
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version_install

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -54,6 +54,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && ctest
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $repo-$version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_fftw.sh
+++ b/libs/build_fftw.sh
@@ -58,6 +58,9 @@ make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -61,6 +61,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 #[[ $MAKE_CHECK =~ [yYtT] ]] && make check # make check is not implemented in cmake builds
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_geos.sh
+++ b/libs/build_geos.sh
@@ -51,6 +51,9 @@ cd build
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE $SUDO make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -42,6 +42,9 @@ mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $id
 echo $name $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gnu.sh
+++ b/libs/build_gnu.sh
@@ -38,6 +38,9 @@ extra_conf="--disable-multilib"
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 $SUDO make install-strip
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gptl.sh
+++ b/libs/build_gptl.sh
@@ -46,6 +46,9 @@ VERBOSE=$MAKE_VERBOSE make
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_gsl_lite.sh
+++ b/libs/build_gsl_lite.sh
@@ -47,6 +47,9 @@ VERBOSE=$MAKE_VERBOSE make -j$NTHREADS
 #[[ $MAKE_CHECK =~ [yYtT] ]] && make test
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -75,6 +75,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
                           || make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -77,6 +77,9 @@ make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -55,6 +55,9 @@ make -j${NTHREADS:-4}
 
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_json.sh
+++ b/libs/build_json.sh
@@ -41,6 +41,9 @@ cmake .. \
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_json_schema_validator.sh
+++ b/libs/build_json_schema_validator.sh
@@ -46,6 +46,9 @@ cmake .. \
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_lapack.sh
+++ b/libs/build_lapack.sh
@@ -53,6 +53,9 @@ VERBOSE="$MAKE_VERBOSE" make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 VERBOSE="$MAKE_VERBOSE" $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_lmod.sh
+++ b/libs/build_lmod.sh
@@ -36,10 +36,10 @@ cd lua-$lua_version
 mkdir -p build && cd build
 ../configure --prefix=$mods_path/lua/$lua_version
 make
-sudo make install
+$SUDO make install
 cd $mods_path/lua
-sudo ln -s $lua_version lua
-sudo ln -s $mods_path/lua/$lua_version/bin/* /usr/local/bin
+$SUDO ln -s $lua_version lua
+$SUDO ln -s $mods_path/lua/$lua_version/bin/* /usr/local/bin
 
 # install lmod
 # this installs in $MODULESHOME, which is set to $mods_path/lmod/lmod
@@ -50,6 +50,9 @@ cd Lmod-$lmod_version
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 ../configure --prefix=$mods_path
-sudo make install
+$SUDO make install
+
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
 
 echo LMod $lua_version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_madis.sh
+++ b/libs/build_madis.sh
@@ -112,6 +112,9 @@ $SUDO mv lib/*     $prefix/lib/
 $SUDO mv doc/*     $prefix/doc/
 $SUDO mv static/*  $prefix/static/
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -71,6 +71,9 @@ cmake .. \
 
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 modpath=mpi
 $MODULES && update_modules $modpath $name $id

--- a/libs/build_miniconda3.sh
+++ b/libs/build_miniconda3.sh
@@ -54,6 +54,9 @@ echo "install $version of conda"
 conda install -yq conda=$version
 set -x
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_mpi.sh
+++ b/libs/build_mpi.sh
@@ -100,6 +100,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_nccmp.sh
+++ b/libs/build_nccmp.sh
@@ -88,6 +88,9 @@ make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -223,6 +223,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
                           || make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 [[ ${using_mpi:-} =~ [yYtT] ]] && modpath=mpi || modpath=compiler
 [[ ${using_python:-} =~ [yYtT] ]] && py_version="$(python3 --version | cut -d " " -f2 | cut -d. -f1-2)"

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -61,10 +61,10 @@ AM_LDFLAGS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep AM_LDFLAGS | cut -d: -f2
 EXTRA_LIBS=$(cat $HDF5_ROOT/lib/libhdf5.settings | grep "Extra libraries" | cut -d: -f2)
 
 if [[ ! -z $mpi ]]; then
-    if [[ $enable_pnetcdf =~ [yYtT] ]]; then
-	PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
-	PNETCDF_LIBS="-lpnetcdf"
-    fi
+  if [[ $enable_pnetcdf =~ [yYtT] ]]; then
+    PNETCDF_LDFLAGS="-L$PNETCDF_ROOT/lib"
+    PNETCDF_LIBS="-lpnetcdf"
+  fi
 fi
 NETCDF_LDFLAGS="-L$NETCDF_ROOT/lib"
 NETCDF_LIBS="-lnetcdf"
@@ -93,6 +93,9 @@ mkdir -p build && cd build
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
+
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -187,7 +187,7 @@ if [[ $enable_cxx =~ [yYtT] ]]; then
 
   version=$cxx_version
   software=$name-"cxx4"-$version
-	URL="$URLroot/$name-cxx4.git"
+  URL="$URLroot/$name-cxx4.git"
   [[ -d $software ]] || ( git clone -b "v$version" $URL $software )
   [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
   [[ -d build ]] && rm -rf build
@@ -202,3 +202,7 @@ if [[ $enable_cxx =~ [yYtT] ]]; then
 
   echo netcdf-cxx $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
 fi
+
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -87,6 +87,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pnetcdf.sh
+++ b/libs/build_pnetcdf.sh
@@ -55,6 +55,9 @@ VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -55,6 +55,9 @@ make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_proj.sh
+++ b/libs/build_proj.sh
@@ -56,6 +56,9 @@ cd build
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE $SUDO make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_pybind11.sh
+++ b/libs/build_pybind11.sh
@@ -39,6 +39,9 @@ cmake -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_VERBOSE_MAKEFILE=1 ..
 VERBOSE=$MAKE_VERBOSE $SUDO make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_sqlite.sh
+++ b/libs/build_sqlite.sh
@@ -44,6 +44,9 @@ URL="https://www.sqlite.org/2020/$software.tar.gz"
 make V=$MAKE_VERBOSE -j${NTHREADS:-4}
 $SUDO make V=$MAKE_VERBOSE -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_szip.sh
+++ b/libs/build_szip.sh
@@ -55,6 +55,9 @@ make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_tau2.sh
+++ b/libs/build_tau2.sh
@@ -57,6 +57,9 @@ $SUDO ./configure -prefix=$prefix -c++=$CXX -cc=$CC -fortran=$FC -mpi -ompt -bfd
 # Note - if this doesn't work you might have to run the entire script as root
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_tkdiff.sh
+++ b/libs/build_tkdiff.sh
@@ -27,6 +27,9 @@ URL="https://sourceforge.net/projects/tkdiff/files/tkdiff/$version/$software.zip
 $SUDO mkdir -p $prefix/bin
 $SUDO mv $software/tkdiff $prefix/bin
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules core $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -52,6 +52,9 @@ make -j${NTHREADS:-4}
 [[ "$MAKE_CHECK" = "YES" ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -118,6 +118,9 @@ if [[ ${STACK_wgrib2_lib:-n} =~ [yYtT] ]]; then
     $SUDO cp -r cmake ${prefix}/lib
 fi
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 modpath=compiler
 $MODULES && update_modules $modpath $name $install_as

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -43,6 +43,9 @@ mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4} install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $id
 echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_zlib.sh
+++ b/libs/build_zlib.sh
@@ -59,6 +59,9 @@ make -j${NTHREADS:-4}
 [[ "$MAKE_CHECK" = "YES" ]] && make check
 $SUDO make install
 
+# Make the installation prefix read-only for all
+$MODULES && $SUDO chmod a-w $prefix
+
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/stack_helpers.sh
+++ b/stack_helpers.sh
@@ -65,6 +65,9 @@ EOF
     $SUDO cp $tmpl_file $version.lua
   fi
 
+  # Make the modulefile read-only
+  $SUDO chmod a-w $version.lua
+
   # Make the latest installed version the default
   [[ -e default ]] && $SUDO rm -f default
   $SUDO ln -s $version.lua default


### PR DESCRIPTION
This PR makes the installation directory `prefix` and the modulefile for the package read only.
This will hopefully prevent accidental deletions/movements/additions and provide stability to the installation stack.

The owner will have to take drastic steps to deliberately remove an installation.

With great power comes great responsibility.

Fixes #306 