### PR TITLE
Update g2 to v3.4.4

### DIFF
--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.3
-  install_as: 3.4.3
+  version: v3.4.4
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -161,8 +161,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.4
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:

--- a/stack/stack_jedi.yaml
+++ b/stack/stack_jedi.yaml
@@ -162,8 +162,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.2
-  install_as: 3.4.2
+  version: v3.4.4
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.3
-  install_as: 3.4.3
+  version: v3.4.4
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -161,8 +161,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.3
-  install_as: 3.4.3
+  version: v3.4.4
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:


### PR DESCRIPTION
This version fixed a performance regression where grib index was being re-generated for each call to getidx.
This bug was introduced in version 3.4.1 and was fixed by adding a save to the index.

A test was conducted on WCOSS2 with v3.4.4 and v3.4.1 and runtime was reduced from 20s to 2s.