### PR TITLE
Load zlib for g2c

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -67,6 +67,7 @@ if $MODULES; then
       ;;
     g2c)
       module try-load jpeg
+      module try-load zlib
       module try-load png
       module try-load jasper
       ;;


### PR DESCRIPTION
Undefined references to zlib when building g2c test executables.

Fix #322 