### PR TITLE
Nceplibs updates

### DIFF
--- a/.github/workflows/build_intel.yaml
+++ b/.github/workflows/build_intel.yaml
@@ -55,10 +55,10 @@ jobs:
       run: |
         cd hpc-stack
         prefix=$GITHUB_WORKSPACE/install
-        intel_ver=$( gcc -dumpfullversion -dumpversion )
+        intel_ver=$( icc -dumpversion )
         python_ver=$( python3 --version | cut -d " " -f2 | cut -d. -f1-2 )
-        export HPC_COMPILER="intel/2021"
-        export HPC_MPI="impi/2021"
+        export HPC_COMPILER="intel/${intel_ver}"
+        export HPC_MPI="impi/${intel_ver}"
         export HPC_PYTHON="python/${python_ver}"
         yes | ./setup_modules.sh -c config/config_custom.sh -p $prefix
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_custom.yaml -m

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -183,7 +183,7 @@ URL="https://github.com/noaa-emc/nceplibs-$name"
 extraCMakeFlags=""
 case $name in
   nceppost | upp)
-    URL="https://github.com/noaa-emc/emc_post"
+    URL="https://github.com/noaa-emc/upp"
     extraCMakeFlags="-DBUILD_POSTEXEC=OFF"
     ;;
   crtm)

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
@@ -5,21 +5,27 @@ local pkgName = myModuleName()
 local pkgVersion = myModuleVersion()
 local pkgNameVer = myModuleFullName()
 
-local hierA        = hierarchyA(pkgNameVer,1)
-local compNameVer  = hierA[1]
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
+load("netcdf")
+prereq("netcdf")
+
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
-local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 
 prepend_path("PATH", pathJoin(base,"bin"))
 setenv("wgrib2_ROOT", base)
 setenv("wgrib2_VERSION", pkgVersion)
 setenv("WGRIB2_INC", pathJoin(base,"include"))
-setenv("WGRIB2_LIB", pathJoin(base,"lib","libwgrib2.a"))
+setenv("WGRIB_LIB", pathJoin(base,"lib/libwgrib2.a"))
+setenv("WGRIB2_LIBAPI", pathJoin(base,"lib/libwgrib2_api.a"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
@@ -1,0 +1,27 @@
+help([[
+]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+setenv("wgrib2_ROOT", base)
+setenv("wgrib2_VERSION", pkgVersion)
+setenv("WGRIB2_INC", pathJoin(base,"include"))
+setenv("WGRIB2_LIB", pathJoin(base,"lib","libwgrib2.a"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -190,8 +190,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.8
-  install_as: 10.0.8
+  version: upp_v10.0.9
+  install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.4
-  install_as: 3.4.4
+  version: v3.4.5
+  install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.2
-  install_as: 1.2.2
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -161,8 +161,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.4
-  install_as: 3.4.4
+  version: v3.4.5
+  install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
@@ -220,8 +220,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.2
-  install_as: 1.2.2
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -186,8 +186,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.9
+  install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -190,8 +190,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.8
-  install_as: 10.0.8
+  version: upp_v10.0.9
+  install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -165,8 +165,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.4
-  install_as: 3.4.4
+  version: v3.4.5
+  install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.2
-  install_as: 1.2.2
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -161,8 +161,8 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.4
-  install_as: 3.4.4
+  version: v3.4.5
+  install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
@@ -220,8 +220,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.2
-  install_as: 1.2.2
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -186,8 +186,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.8
-  install_as: 10.0.8
+  version: upp_v10.0.9
+  install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_ufs_weather_ci.yaml
+++ b/stack/stack_ufs_weather_ci.yaml
@@ -234,6 +234,11 @@ ncio:
   install_as: 1.0.0
   is_nceplib: YES
 
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
 esma_cmake:
   build: YES
   repo: GEOS-ESM

--- a/stack/stack_ufs_weather_ci.yaml
+++ b/stack/stack_ufs_weather_ci.yaml
@@ -76,14 +76,14 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_1
+  version: 8_2_0_beta_snapshot_14
   shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
   build: YES
-  version: 2020.04.03
+  version: 2021.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 
@@ -189,8 +189,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.9
+  install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 
@@ -233,3 +233,28 @@ ncio:
   version: v1.0.0
   install_as: 1.0.0
   is_nceplib: YES
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.0
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.7.3


### PR DESCRIPTION
* Update g2 and grib_util for bugfixes from WCOSS2 transition
* Add wgrib2 module to MPI hierarchy to support CMake build
* Update ufs_weather_ci to match what ufs-weather-model uses in develop
* Update to new UPP URL and version to 10.0.9


Fix #314 and #332