### PR TITLE
Port hpc-stack to expanse

### DIFF
--- a/config/config_expanse.sh
+++ b/config/config_expanse.sh
@@ -5,8 +5,6 @@ export HPC_COMPILER="intel/19.1.1.217"
 export HPC_MPI="intel-mpi/2019.8.254"
 export HPC_PYTHON="python/3.8.5"
 
-module load slurm/expanse/20.02.3
-module load cpu/0.15.4
 
 # Build options
 export USE_SUDO=N

--- a/config/config_expanse.sh
+++ b/config/config_expanse.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="intel/19.1.1.217"
+export HPC_MPI="intel-mpi/2019.8.254"
+export HPC_PYTHON="python/3.8.5"
+
+module load slurm/expanse/20.02.3
+module load cpu/0.15.4
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
+export VENVTYPE="condaenv"
+
+# Load these basic modules for Expanse
+module purge
+module load slurm/expanse/20.02.3
+module load cpu/0.15.4
+module load cmake/3.18.2 
+
+export STACK_udunits_LDFLAGS="-L/expanse/lustre/scratch/domh/temp_project/expat-2.4.1/lib"
+export STACK_udunits_CFLAGS="-I/expanse/lustre/scratch/domh/temp_project/expat-2.4.1/include"
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -119,6 +119,9 @@ case $MPI in
   impi )
     export ESMF_COMM="intelmpi"
     ;;
+  intel-mpi )
+    export ESMF_COMM="intelmpi"
+    ;;
   mpt )
     export ESMF_COMM="mpt"
     ;;

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -33,6 +33,7 @@ export CXX=$SERIAL_CXX
 export FFLAGS="${STACK_FFLAGS:-} ${STACK_udunits_FFLAGS:-} -fPIC"
 export CFLAGS="${STACK_CFLAGS:-} ${STACK_udunits_CFLAGS:-} -fPIC"
 export FCFLAGS="$FFLAGS"
+export LDFLAGS="${STACK_LDFLAGS:-} ${STACK_udunits_LDFLAGS:-}"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-cray-mpich/hpc-cray-mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-cray-mpich/hpc-cray-mpich.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-impi","hpc-mpich","hpc-mpt","hpc-openmpi")
+conflict("hpc-impi","hpc-intel-mpi","hpc-mpich","hpc-mpt","hpc-openmpi")
 
 local mpi = pathJoin("cray-mpich",pkgVersion)
 load(mpi)

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-intel-mpi/hpc-intel-mpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-intel-mpi/hpc-intel-mpi.lua
@@ -10,14 +10,14 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-intel-mpi","hpc-cray-mpich","hpc-mpich","hpc-mpt","hpc-openmpi")
+conflict("hpc-cray-mpich","hpc-mpich","hpc-mpt","hpc-openmpi","hpc-impi")
 
-local mpi = pathJoin("impi",pkgVersion)
+local mpi = pathJoin("intel-mpi",pkgVersion)
 load(mpi)
 prereq(mpi)
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
-local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"impi",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"intel-mpi",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 setenv("MPI_FC",  "mpiifort")

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-mpich/hpc-mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-mpich/hpc-mpich.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-cray-mpich","hpc-impi","hpc-mpt","hpc-openmpi")
+conflict("hpc-cray-mpich","hpc-impi","hpc-intel-mpi","hpc-mpt","hpc-openmpi")
 
 local mpi = pathJoin("mpich",pkgVersion)
 load(mpi)

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-mpt/hpc-mpt.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-mpt/hpc-mpt.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-cray-mpich","hpc-impi","hpc-mpich","hpc-openmpi")
+conflict("hpc-cray-mpich","hpc-impi","hpc-intel-mpi","hpc-mpich","hpc-openmpi")
 
 local mpi = pathJoin("mpt",pkgVersion)
 load(mpi)

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-openmpi/hpc-openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-openmpi/hpc-openmpi.lua
@@ -10,7 +10,7 @@ local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-conflict("hpc-cray-mpich","hpc-impi","hpc-mpich","hpc-mpt")
+conflict("hpc-cray-mpich","hpc-impi","hpc-intel-mpi","hpc-mpich","hpc-mpt")
 
 local mpi = pathJoin("openmpi",pkgVersion)
 load(mpi)


### PR DESCRIPTION
Port hpc-stack to expanse. This requires a new metamodule `intel-mpi`, and updates to the build scripts for `ESMF` and `udunits`.

I had to install my own version of `expat` in order to build `udunits`. I don't know why the default system library didn't do the job, and it's certainly not a good idea to point to my `expat` installation. Hoping someone has a better suggestion.