### PR TITLE
Enable building serial versions of HDF5 and NetCDF

### DIFF
--- a/build_stack.sh
+++ b/build_stack.sh
@@ -143,7 +143,7 @@ build_lib sqlite
 build_lib proj
 build_lib geos
 
-# Build serial versions of HDF5 and netCDF, if using MODULES
+# Also build serial versions of HDF5 and netCDF, if using MODULES
 if $MODULES; then
 
   # Save $HPC_MPI variable
@@ -171,6 +171,7 @@ fi
 build_lib hdf5
 build_lib pnetcdf
 build_lib netcdf
+# Only build these if only parallel builds are installed
 if ! $MODULES; then
   build_lib nccmp
   build_lib nco

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -143,15 +143,39 @@ build_lib sqlite
 build_lib proj
 build_lib geos
 
+# Build serial versions of HDF5 and netCDF, if using MODULES
+if $MODULES; then
+
+  # Save $HPC_MPI variable
+  _HPC_MPI=$HPC_MPI
+  unset HPC_MPI
+
+  # Build hdf5 and netcdf as serial versions
+  build_lib hdf5
+  build_lib netcdf
+
+  # Build netcdf utilities with the serial netCDF library
+  build_lib nccmp
+  build_lib nco
+  build_lib cdo
+
+  # Restore $HPC_MPI variable
+  export HPC_MPI=$_HPC_MPI
+  unset _HPC_MPI
+
+fi
+
 #----------------------
 # MPI-dependent
 # These must be rebuilt for each MPI implementation
 build_lib hdf5
 build_lib pnetcdf
 build_lib netcdf
-build_lib nccmp
-build_lib nco
-build_lib cdo
+if ! $MODULES; then
+  build_lib nccmp
+  build_lib nco
+  build_lib cdo
+fi
 build_lib pio
 
 # NCEPlibs

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -17,7 +17,7 @@ if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
   module load hpc-$HPC_COMPILER
-  [[ -z $HPC_MPI ]] || module load hpc-$HPC_MPI
+  [[ -z $mpi ]] || module load hpc-$HPC_MPI
   [[ $enable_szip =~ [yYtT] ]] && module try-load szip
   [[ $enable_zlib =~ [yYtT] ]] && module try-load zlib
   module list


### PR DESCRIPTION
This PR:
- enables building of serial versions of HDF5 and NetCDF.  This is only enabled when using modules.  When installing in a flat prefix, this is not possible as the parallel version will overwrite the serial version.  In a flat prefix, only the parallel build is exercised.
- NetCDF dependent utilities such as `nccmp`, `nco` and `cdo` are linked against serial versions of NetCDF if available.