### PR TITLE
bugfix for openssl on macOS CI

### DIFF
--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -18,11 +18,15 @@ jobs:
     - name: Update brew packages
       run: |
         brew update
+        brew install openssl@1.1
+        brew upgrade openssl@1.1
         pip3 install setuptools
         pip3 install numpy
         pip3 install netCDF4
-        sudo ln -sf /usr/local/opt/openssl/lib/libcrypto.dylib /usr/local/lib/
-        sudo ln -sf /usr/local/opt/openssl/lib/libssl.dylib    /usr/local/lib/
+
+        ssl_ver=$(brew list --formula openssl@1.1 --versions | cut -d " " -f2)
+        sudo ln -s /usr/local/Cellar/openssl@1.1/$ssl_ver/lib/libssl.1.1.dylib    /usr/local/lib/libssl.dylib
+        sudo ln -s /usr/local/Cellar/openssl@1.1/$ssl_ver/lib/libcrypto.1.1.dylib /usr/local/lib/libcrypto.dylib
 
     - name: Get sources
       uses: actions/checkout@v2

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -37,7 +37,7 @@ udunits:
   version: 2.2.28
 
 hdf5:
-  build: NO
+  build: YES
   version: 1.10.6
   shared: YES
   enable_szip: NO
@@ -49,7 +49,7 @@ pnetcdf:
   shared: YES
 
 netcdf:
-  build: NO
+  build: YES
   shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
@@ -58,7 +58,7 @@ netcdf:
   disable_cxx: YES
 
 nccmp:
-  build: NO
+  build: YES
   version: 1.8.9.0
 
 nco:
@@ -66,171 +66,171 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: NO
+  build: YES
   version: 1.9.8
 
 pio:
-  build: NO
+  build: YES
   version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
-  build: NO
+  build: YES
   version: 8_1_1
   shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
-  build: NO
+  build: YES
   version: 2021.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 
 bacio:
-  build: NO
+  build: YES
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 sigio:
-  build: NO
+  build: YES
   version: v2.3.2
   install_as: 2.3.2
   is_nceplib: YES
 
 sfcio:
-  build: NO
+  build: YES
   version: v1.4.1
   install_as: 1.4.1
   is_nceplib: YES
 
 gfsio:
-  build: NO
+  build: YES
   version: v1.4.1
   install_as: 1.4.1
   is_nceplib: YES
 
 w3nco:
-  build: NO
+  build: YES
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 sp:
-  build: NO
+  build: YES
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
   is_nceplib: YES
 
 ip:
-  build: NO
+  build: YES
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
   is_nceplib: YES
 
 ip2:
-  build: NO
+  build: YES
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
   is_nceplib: YES
 
 landsfcutil:
-  build: NO
+  build: YES
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 nemsio:
-  build: NO
+  build: YES
   version: v2.5.2
   install_as: 2.5.2
   is_nceplib: YES
 
 nemsiogfs:
-  build: NO
+  build: YES
   version: v2.5.3
   install_as: 2.5.3
   is_nceplib: YES
 
 w3emc:
-  build: NO
+  build: YES
   version: v2.7.3
   install_as: 2.7.3
   is_nceplib: YES
 
 g2:
-  build: NO
+  build: YES
   version: v3.4.5
   install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
-  build: NO
+  build: YES
   version: v1.6.4
   install_as: 1.6.4
   is_nceplib: YES
 
 g2tmpl:
-  build: NO
+  build: YES
   version: v1.10.0
   install_as: 1.10.0
   is_nceplib: YES
 
 crtm:
-  build: NO
+  build: YES
   version: v2.3.0
   install_as: 2.3.0
   is_nceplib: YES
   install_fix: NO
 
 upp:
-  build: NO
+  build: YES
   version: upp_v10.0.9
   install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 
 wrf_io:
-  build: NO
+  build: YES
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
   is_nceplib: YES
 
 bufr:
-  build: NO
+  build: YES
   version: bufr_v11.5.0
   install_as: 11.5.0
   python: YES
   is_nceplib: YES
 
 wgrib2:
-  build: NO
+  build: YES
   version: 2.0.8
   install_as: 2.0.8
   lib: YES
   ipolates: 3
 
 prod_util:
-  build: NO
+  build: YES
   version: v1.2.2
   install_as: 1.2.2
   is_nceplib: YES
 
 grib_util:
-  build: NO
+  build: YES
   version: v1.2.3
   install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 
 ncio:
-  build: NO
+  build: YES
   version: v1.0.0
   install_as: 1.0.0
   is_nceplib: YES
@@ -297,40 +297,40 @@ atlas:
   repo: ecmwf
 
 madis:
-  build: NO
+  build: YES
   version: 4.3
 
 esma_cmake:
-  build: NO
+  build: YES
   repo: GEOS-ESM
   version: v3.4.3
 
 cmakemodules:
-  build: NO
+  build: YES
   repo: NOAA-EMC
   version: v1.2.0
 
 gftl_shared:
-  build: NO
+  build: YES
   repo: Goddard-Fortran-Ecosystem
   version: v1.3.0
 
 yafyaml:
-  build: NO
+  build: YES
   repo: Goddard-Fortran-Ecosystem
   version: v0.5.1
 
 mapl:
-  build: NO
+  build: YES
   repo: GEOS-ESM
   version: v2.7.3
 
 geos:
-  build: NO
+  build: YES
   version: 3.8.1
 
 sqlite:
-  build: NO
+  build: YES
   version: 3.32.3
 
 proj:

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -37,7 +37,7 @@ udunits:
   version: 2.2.28
 
 hdf5:
-  build: YES
+  build: NO
   version: 1.10.6
   shared: YES
   enable_szip: NO
@@ -49,7 +49,7 @@ pnetcdf:
   shared: YES
 
 netcdf:
-  build: YES
+  build: NO
   shared: YES
   enable_pnetcdf: NO
   version_c: 4.7.4
@@ -58,7 +58,7 @@ netcdf:
   disable_cxx: YES
 
 nccmp:
-  build: YES
+  build: NO
   version: 1.8.9.0
 
 nco:
@@ -66,171 +66,171 @@ nco:
   version: 4.9.3
 
 cdo:
-  build: YES
+  build: NO
   version: 1.9.8
 
 pio:
-  build: YES
+  build: NO
   version: 2.5.3
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
-  build: YES
+  build: NO
   version: 8_1_1
   shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
-  build: YES
+  build: NO
   version: 2021.03
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON"
 
 bacio:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 sigio:
-  build: YES
+  build: NO
   version: v2.3.2
   install_as: 2.3.2
   is_nceplib: YES
 
 sfcio:
-  build: YES
+  build: NO
   version: v1.4.1
   install_as: 1.4.1
   is_nceplib: YES
 
 gfsio:
-  build: YES
+  build: NO
   version: v1.4.1
   install_as: 1.4.1
   is_nceplib: YES
 
 w3nco:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 sp:
-  build: YES
+  build: NO
   version: v2.3.3
   install_as: 2.3.3
   openmp: ON
   is_nceplib: YES
 
 ip:
-  build: YES
+  build: NO
   version: v3.3.3
   install_as: 3.3.3
   openmp: ON
   is_nceplib: YES
 
 ip2:
-  build: YES
+  build: NO
   version: v1.1.2
   install_as: 1.1.2
   openmp: ON
   is_nceplib: YES
 
 landsfcutil:
-  build: YES
+  build: NO
   version: v2.4.1
   install_as: 2.4.1
   is_nceplib: YES
 
 nemsio:
-  build: YES
+  build: NO
   version: v2.5.2
   install_as: 2.5.2
   is_nceplib: YES
 
 nemsiogfs:
-  build: YES
+  build: NO
   version: v2.5.3
   install_as: 2.5.3
   is_nceplib: YES
 
 w3emc:
-  build: YES
+  build: NO
   version: v2.7.3
   install_as: 2.7.3
   is_nceplib: YES
 
 g2:
-  build: YES
+  build: NO
   version: v3.4.5
   install_as: 3.4.5
   is_nceplib: YES
 
 g2c:
-  build: YES
+  build: NO
   version: v1.6.4
   install_as: 1.6.4
   is_nceplib: YES
 
 g2tmpl:
-  build: YES
+  build: NO
   version: v1.10.0
   install_as: 1.10.0
   is_nceplib: YES
 
 crtm:
-  build: YES
+  build: NO
   version: v2.3.0
   install_as: 2.3.0
   is_nceplib: YES
   install_fix: NO
 
 upp:
-  build: YES
+  build: NO
   version: upp_v10.0.9
   install_as: 10.0.9
   openmp: ON
   is_nceplib: YES
 
 wrf_io:
-  build: YES
+  build: NO
   version: v1.2.0
   install_as: 1.2.0
   openmp: ON
   is_nceplib: YES
 
 bufr:
-  build: YES
+  build: NO
   version: bufr_v11.5.0
   install_as: 11.5.0
   python: YES
   is_nceplib: YES
 
 wgrib2:
-  build: YES
+  build: NO
   version: 2.0.8
   install_as: 2.0.8
   lib: YES
   ipolates: 3
 
 prod_util:
-  build: YES
+  build: NO
   version: v1.2.2
   install_as: 1.2.2
   is_nceplib: YES
 
 grib_util:
-  build: YES
+  build: NO
   version: v1.2.3
   install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 
 ncio:
-  build: YES
+  build: NO
   version: v1.0.0
   install_as: 1.0.0
   is_nceplib: YES
@@ -297,40 +297,40 @@ atlas:
   repo: ecmwf
 
 madis:
-  build: YES
+  build: NO
   version: 4.3
 
 esma_cmake:
-  build: YES
+  build: NO
   repo: GEOS-ESM
   version: v3.4.3
 
 cmakemodules:
-  build: YES
+  build: NO
   repo: NOAA-EMC
   version: v1.2.0
 
 gftl_shared:
-  build: YES
+  build: NO
   repo: Goddard-Fortran-Ecosystem
   version: v1.3.0
 
 yafyaml:
-  build: YES
+  build: NO
   repo: Goddard-Fortran-Ecosystem
   version: v0.5.1
 
 mapl:
-  build: YES
+  build: NO
   repo: GEOS-ESM
   version: v2.7.3
 
 geos:
-  build: YES
+  build: NO
   version: 3.8.1
 
 sqlite:
-  build: YES
+  build: NO
   version: 3.32.3
 
 proj:


### PR DESCRIPTION
This is a pest fix PR for macOS and OpenSSL.
The problem is well documented across the various macOS forums.

macOS ships with LibreSSL, which is not what the CI uses for eckit.
eckit uses OpenSSL.
When brew installs OpenSSL, it does not link in `/usr/local/lib`.
This PR:
- installs openssl via brew
- links the necessary ssl and crypto library in `/usr/local/lib`

This allows `eckit` to find and link with openssl correctly.