### PR TITLE
Load bacio when building w3emc

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -91,6 +91,7 @@ if $MODULES; then
       module load nemsio
       ;;
     w3emc)
+      module load bacio
       if [[ "$using_mpi" =~ [yYtT] ]]; then
           module load netcdf
           module load sigio


### PR DESCRIPTION
With bacio 2.9.2 w3emc depends on bacio