### PR TITLE
Fix DOWNLOAD_ONLY option

### DIFF
--- a/.github/workflows/test_download_only.yaml
+++ b/.github/workflows/test_download_only.yaml
@@ -1,4 +1,4 @@
-name: Build Ubuntu
+name: Test DOWNLOAD_ONLY
 on:
   pull_request:
   workflow_dispatch:
@@ -21,9 +21,4 @@ jobs:
         cd hpc-stack
         sed -i "s/DOWNLOAD_ONLY=N/DOWNLOAD_ONLY=Y/" ./config/config_custom.sh
         prefix=$GITHUB_WORKSPACE/install
-        gnu_ver=$( gcc -dumpfullversion -dumpversion )
-        python_ver=$( python3 --version | cut -d " " -f2 | cut -d. -f1-2 )
-        export HPC_COMPILER="gnu/${gnu_ver}"
-        export HPC_MPI="${{ matrix.mpi }}/${mpi_ver}"
-        export HPC_PYTHON="python/${python_ver}"
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_noaa.yaml

--- a/.github/workflows/test_download_only.yaml
+++ b/.github/workflows/test_download_only.yaml
@@ -21,5 +21,5 @@ jobs:
         cd hpc-stack
         sed -i "s/DOWNLOAD_ONLY=N/DOWNLOAD_ONLY=Y/" ./config/config_custom.sh
         prefix=$GITHUB_WORKSPACE/install
-        sed -i "s/install_fix: YES/install_fix: NO" stack/stack_noaa.yaml
+        sed -i "s/install_fix: YES/install_fix: NO/" stack/stack_noaa.yaml
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_noaa.yaml

--- a/.github/workflows/test_download_only.yaml
+++ b/.github/workflows/test_download_only.yaml
@@ -1,0 +1,29 @@
+name: Build Ubuntu
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    env:
+      VERBOSE: 1
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Get sources
+      uses: actions/checkout@v2
+      with:
+        path: hpc-stack
+
+    - name: Test DOWNLOAD_ONLY
+      run: |
+        cd hpc-stack
+        sed -i "s/DOWNLOAD_ONLY=N/DOWNLOAD_ONLY=Y/" ./config/config_custom.sh
+        prefix=$GITHUB_WORKSPACE/install
+        gnu_ver=$( gcc -dumpfullversion -dumpversion )
+        python_ver=$( python3 --version | cut -d " " -f2 | cut -d. -f1-2 )
+        export HPC_COMPILER="gnu/${gnu_ver}"
+        export HPC_MPI="${{ matrix.mpi }}/${mpi_ver}"
+        export HPC_PYTHON="python/${python_ver}"
+        ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_noaa.yaml

--- a/.github/workflows/test_download_only.yaml
+++ b/.github/workflows/test_download_only.yaml
@@ -21,4 +21,5 @@ jobs:
         cd hpc-stack
         sed -i "s/DOWNLOAD_ONLY=N/DOWNLOAD_ONLY=Y/" ./config/config_custom.sh
         prefix=$GITHUB_WORKSPACE/install
+        sed -i "s/install_fix: YES/install_fix: NO" stack/stack_noaa.yaml
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_noaa.yaml

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -9,6 +9,31 @@ version=${1:-${STACK_cdo_version}}
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+case $version in
+  1.9.9 )
+    URL="https://code.mpimet.mpg.de/attachments/download/23323/cdo-1.9.9.tar.gz"
+  ;;
+  1.9.8 )
+    URL="https://code.mpimet.mpg.de/attachments/download/20826/cdo-1.9.8.tar.gz"
+  ;;
+  1.9.7.1 )
+    URL="https://code.mpimet.mpg.de/attachments/download/20124/cdo-1.9.7.1.tar.gz"
+  ;;
+  1.9.6 )
+    URL="https://code.mpimet.mpg.de/attachments/download/19299/cdo-1.9.6.tar.gz"
+  ;;
+  * )
+    echo "Try using CDO version 1.9.6 and above, ABORT!"
+    exit 1
+  ;;
+esac
+
+software=$name-$version
+[[ -d $software ]] || ( $WGET $URL; tar -xzf $software.tar.gz && rm -f $software.tar.gz )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
@@ -53,30 +78,6 @@ export CXXFLAGS="${STACK_CXXFLAGS:-} ${STACK_cdo_CXXFLAGS:-} -fPIC"
 export F77=$FC
 export FCFLAGS=$FFLAGS
 
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
-
-case $version in
-  1.9.9 )
-    URL="https://code.mpimet.mpg.de/attachments/download/23323/cdo-1.9.9.tar.gz"
-  ;;
-  1.9.8 )
-    URL="https://code.mpimet.mpg.de/attachments/download/20826/cdo-1.9.8.tar.gz"
-  ;;
-  1.9.7.1 )
-    URL="https://code.mpimet.mpg.de/attachments/download/20124/cdo-1.9.7.1.tar.gz"
-  ;;
-  1.9.6 )
-    URL="https://code.mpimet.mpg.de/attachments/download/19299/cdo-1.9.6.tar.gz"
-  ;;
-  * )
-    echo "Try using CDO version 1.9.6 and above, ABORT!"
-    exit 1
-  ;;
-esac
-
-software=$name-$version
-[[ -d $software ]] || ( $WGET $URL; tar -xzf $software.tar.gz && rm -f $software.tar.gz )
-[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -28,7 +28,6 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git fetch --tags
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -28,7 +28,6 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git fetch --tags
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -33,7 +33,6 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git fetch --tags
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 

--- a/libs/build_madis.sh
+++ b/libs/build_madis.sh
@@ -9,6 +9,13 @@ version=${1:-${STACK_madis_version}}
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+URL="https://madis-data.ncep.noaa.gov/source/$software.tar.gz"
+[[ -f $software.tar.gz ]] || ( $WGET $URL )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
@@ -67,12 +74,6 @@ export LDFLAGS="${PNETCDF_LDFLAGS:-} ${NETCDF_LDFLAGS:-} ${HDF5_LDFLAGS} ${AM_LD
 export LIBS="${PNETCDF_LIBS:-} ${NETCDF_LIBS} ${HDF5_LIBS} ${EXTRA_LIBS:-}"
 export CPPFLAGS="-I${NETCDF_ROOT}/include"
 
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
-
-software=$name-$version
-URL="https://madis-data.ncep.noaa.gov/source/$software.tar.gz"
-[[ -f $software.tar.gz ]] || ( $WGET $URL )
-[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 rm -rf $software && mkdir -p $software && cd $software
 tar -xf ../$software.tar.gz
 

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -52,7 +52,6 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git fetch --tags
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -234,7 +234,12 @@ case $name in
     ;;
   bufr)
     if [[ ${using_python:-} =~ [yYtT] ]]; then
-      extraCMakeFlags="-DENABLE_PYTHON=ON"
+      extraCMakeFlags="-DENABLE_PYTHON=ON "
+    fi
+    if [[ $MAKE_CHECK =~ [yYtT] ]]; then
+        extraCMakeFlags+="-DBUILD_TESTS=ON"
+    else
+        extraCMakeFlags+="-DBUILD_TETS=OFF"
     fi
     ;;
   nemsio)

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -9,6 +9,14 @@ version=${1:-${STACK_nco_version}}
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
+URL="https://github.com/nco/nco.git"
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+[[ -d $software ]] || ( git clone -b $version $URL $software )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
@@ -72,13 +80,6 @@ NETCDF_LIBS="-lnetcdf"
 export LDFLAGS="${PNETCDF_LDFLAGS:-} ${NETCDF_LDFLAGS:-} ${HDF5_LDFLAGS:-} ${AM_LDFLAGS:-}"
 export LIBS="${PNETCDF_LIBS:-} ${NETCDF_LIBS:-} ${HDF5_LIBS:-} ${EXTRA_LIBS:-}"
 
-URL="https://github.com/nco/nco.git"
-
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
-
-software=$name-$version
-[[ -d $software ]] || ( git clone -b $version $URL $software )
-[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -34,7 +34,6 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] || git clone $URL $software
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-git fetch --tags
 git checkout $version
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 


### PR DESCRIPTION
Fix #359 #358 #357 #356 

Add a CI build that runs DOWNLOAD_ONLY. It's more difficult to test the build because the runner always has internet access, so it won't run into the `git fetch` issue.

Remove `git fetch`. I think it's a fair assumption to enforce that the downloaded packages have the required tags from the original clone. It downloads each package version individually too, so I don't think it was ever necessary.

Download package before running nc-config for packages that use it.