### PR TITLE
Skip build instead of exiting with failure if library exists

### DIFF
--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -27,8 +27,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${ATLAS_ROOT:-"/usr/local"}

--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -28,7 +28,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${ATLAS_ROOT:-"/usr/local"}

--- a/libs/build_boost.sh
+++ b/libs/build_boost.sh
@@ -51,7 +51,7 @@ if $MODULES; then
   prefix="${PREFIX:-"$HOME/opt"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${BOOST_ROOT:-"/usr/local"}

--- a/libs/build_boost.sh
+++ b/libs/build_boost.sh
@@ -50,8 +50,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"$HOME/opt"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${BOOST_ROOT:-"/usr/local"}

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -54,8 +54,13 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
 
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${CDO_ROOT:-"/usr/local"}

--- a/libs/build_cdo.sh
+++ b/libs/build_cdo.sh
@@ -55,7 +55,7 @@ if $MODULES; then
 
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${CDO_ROOT:-"/usr/local"}

--- a/libs/build_cgal.sh
+++ b/libs/build_cgal.sh
@@ -35,7 +35,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${CGAL_ROOT:-"/usr/local"}

--- a/libs/build_cgal.sh
+++ b/libs/build_cgal.sh
@@ -34,8 +34,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${CGAL_ROOT:-"/usr/local"}

--- a/libs/build_cmake.sh
+++ b/libs/build_cmake.sh
@@ -16,8 +16,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${CMAKE_ROOT:-"/usr/local"}

--- a/libs/build_cmake.sh
+++ b/libs/build_cmake.sh
@@ -17,7 +17,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${CMAKE_ROOT:-"/usr/local"}

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -15,8 +15,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix 
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${CMAKEMODULES_ROOT:-"/usr/local"}

--- a/libs/build_cmakemodules.sh
+++ b/libs/build_cmakemodules.sh
@@ -16,7 +16,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${CMAKEMODULES_ROOT:-"/usr/local"}

--- a/libs/build_condaenv.sh
+++ b/libs/build_condaenv.sh
@@ -30,8 +30,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+            if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   nameUpper=$(echo $name | tr [a-z] [A-Z])

--- a/libs/build_condaenv.sh
+++ b/libs/build_condaenv.sh
@@ -31,7 +31,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   nameUpper=$(echo $name | tr [a-z] [A-Z])

--- a/libs/build_ecbuild.sh
+++ b/libs/build_ecbuild.sh
@@ -15,8 +15,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix 
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${ECBUILD_ROOT:-"/usr/local"}

--- a/libs/build_ecbuild.sh
+++ b/libs/build_ecbuild.sh
@@ -16,7 +16,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$repo-$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${ECBUILD_ROOT:-"/usr/local"}

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -26,7 +26,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${ECKIT_ROOT:-"/usr/local"}

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -25,8 +25,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${ECKIT_ROOT:-"/usr/local"}

--- a/libs/build_eigen.sh
+++ b/libs/build_eigen.sh
@@ -16,7 +16,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${EIGEN_ROOT:-"/usr/local"}

--- a/libs/build_eigen.sh
+++ b/libs/build_eigen.sh
@@ -15,8 +15,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${EIGEN_ROOT:-"/usr/local"}

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -15,8 +15,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${ESMA_CMAKE_ROOT:-"/usr/local"}

--- a/libs/build_esma_cmake.sh
+++ b/libs/build_esma_cmake.sh
@@ -16,7 +16,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${ESMA_CMAKE_ROOT:-"/usr/local"}

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -42,7 +42,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version_install"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -41,8 +41,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version_install"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -27,7 +27,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${FCKIT_ROOT:-"/usr/local"}

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -26,8 +26,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$repo-$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${FCKIT_ROOT:-"/usr/local"}

--- a/libs/build_fftw.sh
+++ b/libs/build_fftw.sh
@@ -20,8 +20,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-      [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${FFTW_ROOT:-"/usr/local"}

--- a/libs/build_fftw.sh
+++ b/libs/build_fftw.sh
@@ -21,7 +21,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
       [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${FFTW_ROOT:-"/usr/local"}

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -23,7 +23,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${FMS_ROOT:-"/usr/local"}

--- a/libs/build_fms.sh
+++ b/libs/build_fms.sh
@@ -22,8 +22,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${FMS_ROOT:-"/usr/local"}

--- a/libs/build_geos.sh
+++ b/libs/build_geos.sh
@@ -22,7 +22,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_geos.sh
+++ b/libs/build_geos.sh
@@ -21,8 +21,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -21,7 +21,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${GFTL_SHARED_ROOT:-"/usr/local"}

--- a/libs/build_gftl_shared.sh
+++ b/libs/build_gftl_shared.sh
@@ -20,8 +20,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${GFTL_SHARED_ROOT:-"/usr/local"}

--- a/libs/build_gnu.sh
+++ b/libs/build_gnu.sh
@@ -18,8 +18,14 @@ contrib/download_prerequisites
 if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "ERROR: $prefix EXISTS, ABORT!"; exit 1 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${GNU_ROOT:-"/usr/local"}

--- a/libs/build_gptl.sh
+++ b/libs/build_gptl.sh
@@ -20,8 +20,14 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${GPTL_ROOT:-"/usr/local"}

--- a/libs/build_gptl.sh
+++ b/libs/build_gptl.sh
@@ -21,7 +21,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${GPTL_ROOT:-"/usr/local"}

--- a/libs/build_gsl_lite.sh
+++ b/libs/build_gsl_lite.sh
@@ -22,7 +22,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${GSL_LITE_ROOT:-"/usr/local"}

--- a/libs/build_gsl_lite.sh
+++ b/libs/build_gsl_lite.sh
@@ -21,8 +21,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${GSL_LITE_ROOT:-"/usr/local"}

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -26,7 +26,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_hdf5.sh
+++ b/libs/build_hdf5.sh
@@ -25,8 +25,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -21,8 +21,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-      [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
     prefix=${JASPER_ROOT:-"/usr/local"}

--- a/libs/build_jasper.sh
+++ b/libs/build_jasper.sh
@@ -22,7 +22,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
       [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                 || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
     prefix=${JASPER_ROOT:-"/usr/local"}

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -20,8 +20,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 
 else

--- a/libs/build_jpeg.sh
+++ b/libs/build_jpeg.sh
@@ -21,7 +21,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 
 else

--- a/libs/build_json.sh
+++ b/libs/build_json.sh
@@ -18,8 +18,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${JSON_ROOT:-"/usr/local"}

--- a/libs/build_json.sh
+++ b/libs/build_json.sh
@@ -19,7 +19,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${JSON_ROOT:-"/usr/local"}

--- a/libs/build_json_schema_validator.sh
+++ b/libs/build_json_schema_validator.sh
@@ -19,8 +19,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${JSON_SCHEMA_VALIDATOR_ROOT:-"/usr/local"}

--- a/libs/build_json_schema_validator.sh
+++ b/libs/build_json_schema_validator.sh
@@ -20,7 +20,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${JSON_SCHEMA_VALIDATOR_ROOT:-"/usr/local"}

--- a/libs/build_lapack.sh
+++ b/libs/build_lapack.sh
@@ -19,7 +19,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 
 else

--- a/libs/build_lapack.sh
+++ b/libs/build_lapack.sh
@@ -18,8 +18,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 
 else

--- a/libs/build_madis.sh
+++ b/libs/build_madis.sh
@@ -33,7 +33,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${MADIS_ROOT:-"/usr/local"}

--- a/libs/build_madis.sh
+++ b/libs/build_madis.sh
@@ -32,8 +32,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${MADIS_ROOT:-"/usr/local"}

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -34,8 +34,14 @@ if $MODULES; then
   install_as=${STACK_mapl_install_as:-"${id}-esmf-${short_esmf_ver}"}
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${MAPL_ROOT:-"/usr/local"}

--- a/libs/build_mapl.sh
+++ b/libs/build_mapl.sh
@@ -35,7 +35,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${MAPL_ROOT:-"/usr/local"}

--- a/libs/build_miniconda3.sh
+++ b/libs/build_miniconda3.sh
@@ -12,8 +12,14 @@ pyversion=${3:-${STACK_miniconda3_pyversion:-}}
 if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${MINICONDA3_ROOT:-"/usr/local"}

--- a/libs/build_miniconda3.sh
+++ b/libs/build_miniconda3.sh
@@ -13,7 +13,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${MINICONDA3_ROOT:-"/usr/local"}

--- a/libs/build_mpi.sh
+++ b/libs/build_mpi.sh
@@ -32,8 +32,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "ERROR: $prefix EXISTS, ABORT!"; exit 1 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${MPI_ROOT:-"/usr/local"}

--- a/libs/build_nccmp.sh
+++ b/libs/build_nccmp.sh
@@ -34,8 +34,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${NCCMP_ROOT:-"/usr/local"}

--- a/libs/build_nccmp.sh
+++ b/libs/build_nccmp.sh
@@ -35,7 +35,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${NCCMP_ROOT:-"/usr/local"}

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -182,8 +182,14 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$install_as"
   fi
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -178,7 +178,7 @@ if $MODULES; then
   fi
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -38,7 +38,7 @@ if $MODULES; then
 
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
     prefix=${NCO_ROOT:-"/usr/local"}

--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -37,8 +37,13 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
 
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
     prefix=${NCO_ROOT:-"/usr/local"}

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -30,7 +30,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$c_version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 
 else

--- a/libs/build_netcdf.sh
+++ b/libs/build_netcdf.sh
@@ -29,8 +29,14 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$c_version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 
 else

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -28,7 +28,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${PIO_ROOT:-"/usr/local"}

--- a/libs/build_pio.sh
+++ b/libs/build_pio.sh
@@ -27,8 +27,14 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${PIO_ROOT:-"/usr/local"}

--- a/libs/build_pnetcdf.sh
+++ b/libs/build_pnetcdf.sh
@@ -20,7 +20,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${PNETCDF_ROOT:-"/usr/local"}

--- a/libs/build_pnetcdf.sh
+++ b/libs/build_pnetcdf.sh
@@ -19,8 +19,14 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${PNETCDF_ROOT:-"/usr/local"}

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -21,8 +21,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 
 else

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -22,7 +22,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 
 else

--- a/libs/build_proj.sh
+++ b/libs/build_proj.sh
@@ -23,7 +23,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_proj.sh
+++ b/libs/build_proj.sh
@@ -22,8 +22,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_pybind11.sh
+++ b/libs/build_pybind11.sh
@@ -18,7 +18,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${PYBIND11_ROOT:-"/usr/local"}

--- a/libs/build_pybind11.sh
+++ b/libs/build_pybind11.sh
@@ -17,8 +17,14 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${PYBIND11_ROOT:-"/usr/local"}

--- a/libs/build_pyvenv.sh
+++ b/libs/build_pyvenv.sh
@@ -30,8 +30,13 @@ if $MODULES; then
   set -x
   prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   nameUpper=$(echo $name | tr [a-z] [A-Z])

--- a/libs/build_pyvenv.sh
+++ b/libs/build_pyvenv.sh
@@ -31,7 +31,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$python/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   nameUpper=$(echo $name | tr [a-z] [A-Z])

--- a/libs/build_sqlite.sh
+++ b/libs/build_sqlite.sh
@@ -20,8 +20,13 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 
 else

--- a/libs/build_sqlite.sh
+++ b/libs/build_sqlite.sh
@@ -21,7 +21,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 
 else

--- a/libs/build_szip.sh
+++ b/libs/build_szip.sh
@@ -20,8 +20,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 
 else

--- a/libs/build_szip.sh
+++ b/libs/build_szip.sh
@@ -21,7 +21,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 
 else

--- a/libs/build_tau2.sh
+++ b/libs/build_tau2.sh
@@ -22,8 +22,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${TAU_ROOT:-"/usr/local/$name/$version"}

--- a/libs/build_tau2.sh
+++ b/libs/build_tau2.sh
@@ -23,7 +23,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${TAU_ROOT:-"/usr/local/$name/$version"}

--- a/libs/build_tkdiff.sh
+++ b/libs/build_tkdiff.sh
@@ -12,7 +12,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${TKDIFF_ROOT:-"/usr/local"}

--- a/libs/build_tkdiff.sh
+++ b/libs/build_tkdiff.sh
@@ -11,8 +11,14 @@ version=${1:-${STACK_tkdiff_version}}
 if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${TKDIFF_ROOT:-"/usr/local"}

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -20,7 +20,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${UDUNITS_ROOT:-"/usr/local"}

--- a/libs/build_udunits.sh
+++ b/libs/build_udunits.sh
@@ -19,8 +19,13 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${UDUNITS_ROOT:-"/usr/local"}

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -20,7 +20,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$install_as"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${WGRIB2_ROOT:-"/usr/local"}

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -19,8 +19,13 @@ if $MODULES; then
     set -x
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$install_as"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${WGRIB2_ROOT:-"/usr/local"}

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -21,8 +21,14 @@ if $MODULES; then
 
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+          $SUDO mkdir $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
   fi
 else
   prefix=${YAFYAML_ROOT:-"/usr/local"}

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -22,7 +22,7 @@ if $MODULES; then
   prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$id"
   if [[ -d $prefix ]]; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
   fi
 else
   prefix=${YAFYAML_ROOT:-"/usr/local"}

--- a/libs/build_zlib.sh
+++ b/libs/build_zlib.sh
@@ -18,8 +18,13 @@ if $MODULES; then
     set -x
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
     fi
 else
     prefix=${ZLIB_ROOT:-"/usr/local"}

--- a/libs/build_zlib.sh
+++ b/libs/build_zlib.sh
@@ -19,7 +19,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 0 )
     fi
 else
     prefix=${ZLIB_ROOT:-"/usr/local"}


### PR DESCRIPTION
Use exit 0, instead of exit 1 if build already exists and overwrite is not enabled.

Fix #335