### PR TITLE
Update default Intel compilers in the S4 config script

### DIFF
--- a/config/config_s4.sh
+++ b/config/config_s4.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.3"
-export HPC_MPI="impi/18.0.3"
+export HPC_COMPILER="intel/18.0.4"
+export HPC_MPI="impi/18.0.4"
 export HPC_PYTHON="miniconda/3.8-s4"
 
 # Build options


### PR DESCRIPTION
S4 had a compiler update to version 18.0.4.  This updates the config_s4.sh script to use that version by default.  All libraries have been rebuilt on S4 using this config_s4.sh script.