### PR TITLE
Remove climbfuji from assigness

### DIFF
--- a/.github/ISSUE_TEMPLATE/install_request.md
+++ b/.github/ISSUE_TEMPLATE/install_request.md
@@ -3,7 +3,7 @@ name: Install request
 about: Request an installation of package in the stack on HPC's
 title: '[INSTALL] <title>'
 labels: 'install'
-assignees: 'Hang-Lei-NOAA, kgerheiser, climbfuji'
+assignees: 'Hang-Lei-NOAA, kgerheiser'
 
 ---
 


### PR DESCRIPTION
The hpc-stack build on Gaea has been transferred