### PR TITLE
part of issue #373

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -94,6 +94,10 @@ if $MODULES; then
       module load sp
       module load ip2
       ;;
+    crtm)
+      module load hpc-$HPC_MPI
+      module load netcdf
+      ;;
     ip2)
       module load sp
       ;;
@@ -228,7 +232,7 @@ case $name in
     extraCMakeFlags="-DBUILD_POSTEXEC=OFF"
     ;;
   crtm)
-    URL="https://github.com/noaa-emc/emc_crtm"
+    URL="https://github.com/NOAA-EMC/crtm.git"
     ;;
   wgrib2)
     extraCMakeFlags="${STACK_wgrib2_cmake_opts:-}"
@@ -258,6 +262,9 @@ software=$name-$version
 if [[ ! -d $software ]]; then
   git clone $URL $software
   cd $software
+  if [[ "$name" == "crtm" ]]; then
+    version=release/REL-${install_as}_emc
+  fi
   git checkout $version
   git submodule update --init --recursive
 fi
@@ -267,19 +274,21 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 # Download CRTM fix files
 if [[ "$name" == "crtm" ]]; then
   if [[ ${STACK_crtm_install_fix:-} =~ [yYtT] ]]; then
-    if [[ ! -d crtm_fix-$version ]]; then
+    if [[ ! -d crtm_fix-${install_as} ]]; then
       crtm_tarball=fix_REL-${install_as}_emc.tgz
       rm -f $crtm_tarball
       $WGET ftp://ftp.ucar.edu/pub/cpaess/bjohns/$crtm_tarball
       tar xzf $crtm_tarball
-      mv fix crtm_fix-$version
+      mv fix crtm_fix-${install_as}
       rm -f $crtm_tarball
     fi
-    if [[ ! -f link_crtm_coeffs.sh ]]; then
-      $WGET https://raw.githubusercontent.com/NOAA-EMC/GSI/master/ush/link_crtm_coeffs.sh
-      sed -i'.backup' -e 's/LINK="ln -sf"/LINK="cp"/g' link_crtm_coeffs.sh
-      chmod +x link_crtm_coeffs.sh
-      rm -f link_crtm_coeffs.sh.backup
+    if [[ "${install_as}" == "2.3.0" ]]; then
+     if [[ ! -f link_crtm_coeffs.sh ]]; then
+       $WGET https://raw.githubusercontent.com/NOAA-EMC/GSI/master/ush/link_crtm_coeffs.sh
+       sed -i'.backup' -e 's/LINK="ln -sf"/LINK="cp"/g' link_crtm_coeffs.sh
+       chmod +x link_crtm_coeffs.sh
+       rm -f link_crtm_coeffs.sh.backup
+     fi
     fi
   fi
 fi
@@ -305,8 +314,22 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 # Install CRTM fix files
 if [[ "$name" == "crtm" ]]; then
   if [[ ${STACK_crtm_install_fix:-} =~ [yYtT] ]]; then
-    if [[ -d crtm_fix-$version ]]; then
-      ./link_crtm_coeffs.sh ./crtm_fix-$version $prefix/fix
+    if [[ -d crtm_fix-${install_as} ]]; then
+     if [[ "${install_as}" == "2.3.0" ]]; then
+       ./link_crtm_coeffs.sh ./crtm_fix-$version $prefix/fix
+     else
+       mkdir -p $prefix/fix
+       cp ./crtm_fix-${install_as}/ACCoeff/netcdf/* $prefix/fix
+       cp ./crtm_fix-${install_as}/AerosolCoeff/Big_Endian/* $prefix/fix
+       cp ./crtm_fix-${install_as}/AerosolCoeff/netCDF/* $prefix/fix
+       cp ./crtm_fix-${install_as}/CloudCoeff/Big_Endian/* $prefix/fix
+       cp ./crtm_fix-${install_as}/CloudCoeff/netCDF/* $prefix/fix
+       cp ./crtm_fix-${install_as}/EmisCoeff/*/Big_Endian/* $prefix/fix
+       cp ./crtm_fix-${install_as}/EmisCoeff/*/*/Big_Endian/* $prefix/fix
+       cp ./crtm_fix-${install_as}/SpcCoeff/Big_Endian/* $prefix/fix
+       cp ./crtm_fix-${install_as}/SpcCoeff/netcdf/* $prefix/fix
+       cp ./crtm_fix-${install_as}/TauCoeff/ODPS/Big_Endian/* $prefix/fix
+     fi
     fi
   fi
 fi

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -179,8 +179,8 @@ g2tmpl:
 
 crtm:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.4.0
+  install_as: 2.4.0
   is_nceplib: YES
   install_fix: YES
 


### PR DESCRIPTION
Upon Ben's request, we access crtm code from the new fork repo in github/noaa-emc
https://github.com/NOAA-EMC/crtm
It is a fork of the github.com/JCSDA/crtm repository. That only include the EMC version for GSI use.