### PR TITLE
Fix NCO build on Hera

### DIFF
--- a/libs/build_nco.sh
+++ b/libs/build_nco.sh
@@ -101,6 +101,7 @@ fi
              --enable-doc=no \
              --enable-netcdf4 \
              --enable-shared=no \
+	     --enable-ncap2=no \
              NETCDF_INC=$NETCDF_ROOT/include \
              NETCDF_LIB=$NETCDF_ROOT/lib
 


### PR DESCRIPTION
Disable ncap2 which requires Antlr libraries. This disables the C++ NCO libraries which we don't use.