### PR TITLE
Update Cheyenne configurations for Intel and GNU

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -9,7 +9,7 @@ export HPC_PYTHON="python/dummy"
 export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
-export OVERWRITE=Y
+export OVERWRITE=N
 export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=N
@@ -38,7 +38,10 @@ export STACK_madis_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
 
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
-export STACK_fms_FFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2 -fallow-argument-mismatch"
 
 # Patch FMS
 export STACK_fms_PATCH="cheyenne_gnu_fms_mpp_util_mpi_inc.patch"
+
+export STACK_mapl_esmf_version="8_2_1_beta_snapshot_04"
+

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -9,7 +9,7 @@ export HPC_PYTHON="python/dummy"
 export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
-export OVERWRITE=Y
+export OVERWRITE=N
 export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=N
@@ -34,3 +34,6 @@ module load cmake/3.18.2
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
 export STACK_fms_FFLAGS="-march=core-avx2"
+
+export STACK_mapl_esmf_version="8_2_1_beta_snapshot_04"
+


### PR DESCRIPTION
These are the updates for the Cheyenne Intel and GNU configs that I had sitting on my local checkout and never sent them back. Just used for installing w3emc 2.9.2 and fms 2021.04.

`OVERWRITE=Y` is no longer necessary, because existing builds will now be skipped. Thanks to whoever implemented this.