### PR TITLE
Add option to build ESMF directly with tag and option for install_as

### DIFF
--- a/config/config_cheyenne_gnu.sh
+++ b/config/config_cheyenne_gnu.sh
@@ -43,5 +43,3 @@ export STACK_fms_FFLAGS="-march=core-avx2 -fallow-argument-mismatch"
 # Patch FMS
 export STACK_fms_PATCH="cheyenne_gnu_fms_mpp_util_mpi_inc.patch"
 
-export STACK_mapl_esmf_version="8_2_1_beta_snapshot_04"
-

--- a/config/config_cheyenne_intel.sh
+++ b/config/config_cheyenne_intel.sh
@@ -34,6 +34,3 @@ module load cmake/3.18.2
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
 export STACK_fms_FFLAGS="-march=core-avx2"
-
-export STACK_mapl_esmf_version="8_2_1_beta_snapshot_04"
-

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -4,6 +4,7 @@ set -eux
 
 name="esmf"
 version=${1:-${STACK_esmf_version}}
+install_as=${STACK_esmf_install_as:-${version}}
 
 software=${name}_$version
 
@@ -21,7 +22,7 @@ host=$(uname -s)
 [[ ${STACK_esmf_debug} =~ [yYtT] ]] && enable_debug=YES || enable_debug=NO
 
 # This will allow debug version of software (ESMF) to be installed next to the optimized version (this is only affected for $MODULES)
-[[ $enable_debug =~ [yYtT] ]] && version_install=$version-debug || version_install=$version
+[[ $enable_debug =~ [yYtT] ]] && version_install=${install_as}-debug || version_install=${install_as}
 
 if $MODULES; then
   set +x
@@ -74,7 +75,7 @@ URL="https://github.com/esmf-org/esmf"
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
-software="ESMF_$version"
+software="$version"
 
 [[ -d $software ]] || ( git clone -b $software $URL $software )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -77,7 +77,8 @@ pio:
 
 esmf:
   build: YES
-  version: 8_2_0
+  version: ESMF_8_2_0
+  install_as: 8.2.0
   shared: YES
   enable_pnetcdf: NO
   debug: NO
@@ -322,6 +323,7 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
+  esmf_version: 8.2.0
   version: v2.7.3
 
 geos:

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -73,7 +73,8 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_1
+  version: ESMF_8_2_0
+  install_as: 8.2.0
   shared: NO
   enable_pnetcdf: NO
   debug: NO
@@ -318,4 +319,5 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
+  esmf_version: 8.2.0
   version: v2.7.3

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -77,7 +77,8 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_1
+  version: ESMF_8_2_0
+  install_as: 8.2.0
   shared: YES
   enable_pnetcdf: NO
   debug: NO
@@ -322,6 +323,7 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
+  esmf_version: 8.2.0
   version: v2.7.3
 
 geos:

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -73,7 +73,8 @@ pio:
 
 esmf:
   build: YES
-  version: 8_1_1
+  version: ESMF_8_2_0
+  install_as: 8.2.0
   shared: NO
   enable_pnetcdf: NO
   debug: NO
@@ -318,6 +319,7 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
+  esmf_version: 8.2.0
   version: v2.7.3
 
 geos:


### PR DESCRIPTION
ESMF tagging scheme has changed recently, instead of being `ESMF_x_y_z_beta_snapshot_a_b`, it's `vx.y.zbab`

And set option in MAPL stack file with esmf_version to control which version it's built with.

For #407 so we don't have to edit the file manually to get the correct tag.