### PR TITLE
Change load, try_load, and prereq to depends_on

### DIFF
--- a/modulefiles/compiler/compilerName/compilerVersion/cdo/cdo.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/cdo/cdo.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/esmf/esmf.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/esmf/esmf.lua
@@ -11,10 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("hdf5")
-always_load("netcdf")
-prereq("hdf5")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/impi/impi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/impi/impi.lua
@@ -17,11 +17,6 @@ family("mpi")
 conflict(pkgName)
 conflict("mpich","openmpi")
 
-always_load("intel/17.0.1")
-prereq("intel/17.0.1")
-
-try_load("szip")
-
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = "/opt/intel17/compilers_and_libraries_2017.1.132"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/ip2/ip2.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/ip2/ip2.lua
@@ -9,8 +9,7 @@ local hierA        = hierarchyA(pkgNameVer,1)
 local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
-load("sp")
-prereq("sp")
+depends_on("sp")
 
 conflict(pkgName)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/madis/madis.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/madis/madis.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/nccmp/nccmp.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nccmp/nccmp.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/nco/nco.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nco/nco.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/nemsio/nemsio.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nemsio/nemsio.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("bacio", "w3emc")
-prereq("bacio", "w3emc")
+depends_on("bacio", "w3emc")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
@@ -11,8 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("hdf5")
-prereq("hdf5")
+depends_on("hdf5")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/openmpi/openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/openmpi/openmpi.lua
@@ -14,8 +14,6 @@ family("mpi")
 conflict(pkgName)
 conflict("mpich","impi")
 
-try_load("szip")
-
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,pkgName,pkgVersion)

--- a/modulefiles/core/cgal/cgal.lua
+++ b/modulefiles/core/cgal/cgal.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-prereq("boost-headers")
+depends_on("boost-headers")
 
 local opt = os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/core/hpc-cray-intel/hpc-cray-intel.lua
+++ b/modulefiles/core/hpc-cray-intel/hpc-cray-intel.lua
@@ -13,7 +13,6 @@ conflict("hpc-gnu", "hpc-gcc")
 local compiler = pathJoin("intel",pkgVersion)
 load(compiler)
 prereq(compiler)
-try_load("mkl")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/compiler","cray-intel",pkgVersion)

--- a/modulefiles/core/json-schema-validator/json-schema-validator.lua
+++ b/modulefiles/core/json-schema-validator/json-schema-validator.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-prereq("json")
+depends_on("json")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/atlas/atlas.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/atlas/atlas.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-prereq("eckit")
-prereq("fckit")
+depends_on("eckit", "fckit")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/madis/madis.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/madis/madis.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nccmp/nccmp.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nccmp/nccmp.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nceppost/nceppost.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nceppost/nceppost.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
-prereq("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+depends_on("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/ncio/ncio.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/ncio/ncio.lua
@@ -12,8 +12,7 @@ local mpiNameVerD  = mpiNameVer:gsub("/","-")
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
-load("netcdf")
-prereq("netcdf")
+depends_on("netcdf")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsio/nemsio.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsio/nemsio.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("bacio", "w3emc")
-prereq("bacio", "w3emc")
+depends_on("bacio", "w3emc")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsiogfs/nemsiogfs.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsiogfs/nemsiogfs.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("nemsio")
-prereq("nemsio")
+depends_on("nemsio")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("hdf5")
-prereq("hdf5")
+depends_on("hdf5")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/upp/upp.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
-prereq("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
+depends_on("bacio", "g2", "g2tmpl", "ip", "sp", "w3nco", "w3emc", "crtm")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/w3emc/w3emc.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/w3emc/w3emc.lua
@@ -13,8 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("sigio", "nemsio")
-prereq("sigio", "nemsio")
+depends_on("sigio", "nemsio")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 


### PR DESCRIPTION
depends_on is the correct behavior in most circumstances. If the dependent module is already loaded it will use that, but if not will try to load it. This way users can mix and match their own versions without LMod changing their selection and forcing the default.

This has been a recurring problem where module load order matters forcing users to override previously loaded modules through `load`.

depends_on combines the functionality of load/preqreq in a single step.

In some cases such as MAPL, compiler/MPI meta modules, and HDF5 with szip load/try_load where the module has to exist or might not exist is the correct behavior.

And not sure why we had `always_load` in some cases.

See https://lmod.readthedocs.io/en/latest/098_dependent_modules.html

Fix #410 and #376