### PR TITLE
adding grib_util/1.2.4

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -133,6 +133,7 @@ if $MODULES; then
       module try-load jasper
       module try-load zlib
       module try-load libpng
+      module try-load w3emc/2.9.2
       module load bacio
       module load w3nco
       module load g2

--- a/stack/stack_comgsi.yaml
+++ b/stack/stack_comgsi.yaml
@@ -195,8 +195,8 @@ prod_util:
 
 grib_util:
   build: NO
-  version: v1.2.2
-  install_as: 1.2.2
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -220,8 +220,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac_gnu.yaml
+++ b/stack/stack_mac_gnu.yaml
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac_m1_gnu.yaml
+++ b/stack/stack_mac_m1_gnu.yaml
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -220,8 +220,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.3
-  install_as: 1.2.3
+  version: v1.2.4
+  install_as: 1.2.4
   openmp: ON
   is_nceplib: YES
 


### PR DESCRIPTION
Part of issue #430 
The new release of grib_util v1.2.4 is a bug fix above old versions.
The v1.2.4 requires supporting library w3emc/2.9.2 instead of the w3nco lib used in old versions.
This is added into the build script through adding try-load, so that the script can works with both old and new grib_util versions.