### PR TITLE
Update FMS and nccmp versions

### DIFF
--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -59,7 +59,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.8.9.0
+  version: 1.9.1.0
 
 nco:
   build: YES
@@ -85,7 +85,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2021.03
+  version: 2022.01
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -55,7 +55,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.8.9.0
+  version: 1.9.1.0
 
 nco:
   build: NO
@@ -81,7 +81,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2021.03
+  version: 2022.01
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -59,7 +59,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.8.9.0
+  version: 1.9.1.0
 
 nco:
   build: YES

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -55,7 +55,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.8.9.0
+  version: 1.9.1.0
 
 nco:
   build: YES
@@ -81,7 +81,7 @@ esmf:
 
 fms:
   build: YES
-  version: 2021.03
+  version: 2022.01
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
 


### PR DESCRIPTION
* Add FMS 2022.01
* Add nccmp 1.9.1.0

Fix #405 and related to #421