### PR TITLE
Update versions of MET and METplus for use on WCOSS2

### DIFF
--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -302,12 +302,12 @@ atlas:
 met:
   build: YES
   enable_python: NO
-  version: 9.1.1
-  release_date: 20201118
+  version: 10.1.1
+  release_date: 20220419
 
 metplus:
   build: NO
-  version: 3.1.1
+  version: 4.1.1
 
 madis:
   build: NO

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -362,8 +362,8 @@ gsl:
 met:
   build: YES
   enable_python: NO
-  version: 9.1.1
+  version: 10.1.1
 
 metplus:
   build: NO
-  version: 3.1.1
+  version: 4.1.1

--- a/stack/stack_metplus.yaml
+++ b/stack/stack_metplus.yaml
@@ -4,10 +4,10 @@ gsl:
 
 met:
   build: YES
-  release_date: 20211201
+  release_date: 20220419
   enable_python: YES
-  version: 10.0.1
+  version: 10.1.1
 
 metplus:
   build: YES
-  version: 4.0.0
+  version: 4.1.0

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -374,3 +374,4 @@ met:
 metplus:
   build: NO
   version: 4.1.1
+  

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -368,9 +368,9 @@ metplus_pyenv:
 
 met:
   build: YES
-  version: 9.1.1
-  enable_pytho: NO
+  version: 10.1.1
+  enable_python: NO
 
 metplus:
   build: NO
-  version: 3.1.1
+  version: 4.1.1


### PR DESCRIPTION
I sent @kgerheiser the following email on 04/07/22:
> After emailing with Arun, I had planned to create an issue and then a branch in the hpc-stack repo to update hpc-stack for the latest 10.1.0 version of MET and 4.1.0 version of METplus and then test the installation of MET and METplus via hpc-stack in my feature branch on acorn.
Looking at the develop branch (https://github.com/NOAA-EMC/hpc-stack/tree/develop), I don't see MET or METplus in the repo.  However, it is my understanding that MET and METplus are available via hpc-stack on WCOSS2.  
Is there a different branch I should be looking at?

To which I received the following response from @kgerheiser on 04/11/22: 
> On WCOSS2 the "nco-wcoss2" branch is used, which contains MET/METplus. The build is kind of special for WCOSS2 because of how NCO uses it to install libraries compared to other systems.

I checked out the "nco-wcoss2" branch and updated the date for MET and the versions for MET and METplus to the latest version per request by Jason Levit and Arun Chawla for use on WCOSS2 as soon as possible.  **Any assistance you can provide for a quick review and quick installation on WCOSS2 would be much appreciated.** 

Please let me know if you have any questions.