### PR TITLE
Create release/srw-public-v2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ framework.
 
 This is part of the [NCEPLIBS](https://github.com/NOAA-EMC/NCEPLIBS) project.
 
+The branch `srw-public-v2` corresponds to the libraries required for building the SRW app release/public-v2 (repo: `ufs-community/ufs-srweather-app` ,`release/public-v2` branch) using GNU compilers (GNU10.2 or 9.2) and openmpi, on Orion, Gaea, Hera, Jet.
+
 ## Authors
 
 Rahul Mahajan, Kyle Gerheiser, Dusan Jovic, Hang-Lei, Dom Heinzeller
@@ -26,7 +28,7 @@ Machine     | Programmer
 ------------|------------------
 Hera        | Kyle Gerheiser
 Jet         | Kyle Gerheiser
-Orion       | Hang-Lei
+Orion       | Orion
 WCOSS-Dell  | Hang-Lei
 WCOSS-Cray  | Hang-Lei
 Cheyenne    | Jong Kim
@@ -34,7 +36,7 @@ Gaea        | Kyle Gerheiser
 
 ## Contributors
 
-Mark Potts, Steve Lawrence, Ed Hartnett, Guoqing Ge, Raffaele Montuoro, David Huber
+Mark Potts, Steve Lawrence, Ed Hartnett, Guoqing Ge, Raffaele Montuoro, David Huber, Natalie Perlin
 
 ## Prerequisites:
 

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -202,6 +202,11 @@ build_lib crtm
 build_lib nceppost
 build_lib upp
 build_lib wrf_io
+
+# Python and associate virtual environments
+build_lib miniconda3
+build_lib r2d2
+
 build_lib bufr
 build_lib wgrib2
 build_lib prod_util
@@ -225,11 +230,6 @@ fi
 # Other
 
 build_lib madis
-
-# Python and associate virtual environments
-
-build_lib miniconda3
-build_lib r2d2
 
 # JEDI 3rd party dependencies
 

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -137,7 +137,7 @@ build_lib cmake
 build_lib udunits
 build_lib jpeg
 build_lib zlib
-build_lib libpng
+build_lib png
 build_lib szip
 build_lib jasper
 build_lib sqlite
@@ -188,12 +188,12 @@ build_lib sigio
 build_lib sfcio
 build_lib gfsio
 build_lib w3nco
-build_lib w3emc
 build_lib sp
 build_lib ip
 build_lib ip2
 build_lib landsfcutil
 build_lib nemsio
+build_lib w3emc
 build_lib nemsiogfs
 build_lib g2
 build_lib g2c
@@ -214,7 +214,7 @@ if $MODULES; then
   _HPC_MPI=$HPC_MPI
   export HPC_MPI=""
 
-  build_lib nemsio
+#  build_lib nemsio
 
   # Restore $HPC_MPI variable
   export HPC_MPI=$_HPC_MPI

--- a/config/config_gaea_gnu.sh
+++ b/config/config_gaea_gnu.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Initialize Lmod and environmental variables
+export MODULESHOME=/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/lmod/lmod
+source $MODULESHOME/init/bash
+export PATH=$MODULESHOME/../../bin:$MODULESHOME/init/ksh_funcs:$PATH
+#
+# Compiler/MPI combination
+export HPC_COMPILER="gcc/10.3.0"
+export HPC_MPI="openmpi/4.1.2"
+export HPC_PYTHON="python/3.6.12"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=Y
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv --no-check-certificate"
+
+# Load these basic modules for Gaea
+module load gcc/10.3.0
+module load git/2.31.1
+module load cmake/3.20.1
+
+# ESMF env. variable
+export STACK_esmf_os="Linux"
+# gfortran-10 compatibility flags for incompatible software
+export STACK_esmf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+export STACK_pnetcdf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+export STACK_madis_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2 -fallow-argument-mismatch"
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+

--- a/config/config_hera_gnu.sh
+++ b/config/config_hera_gnu.sh
@@ -42,7 +42,7 @@ export FC=gfortran
 # Miniconda3 URL on Hera
 export STACK_miniconda3_URL="https://repo.anaconda.com"
 # Madis, wgrib2, boost - tar files from github
-export STACK_git_url="https://github.com/natalie-perlin/HPC-stack-NOAA-blocked-downloads/blob/main/"
+export STACK_git_URL="https://github.com/natalie-perlin/HPC-stack-NOAA-blocked-downloads/blob/main"
 
 export SERIAL_CC=gcc
 export SERIAL_CXX=g++

--- a/config/config_hera_gnu.sh
+++ b/config/config_hera_gnu.sh
@@ -40,7 +40,7 @@ export CXX=g++
 export FC=gfortran
 
 # Miniconda3 URL on Hera
-export STACK_miniconda3_URL="http://anaconda.rdhpcs.noaa.gov"
+export STACK_miniconda3_URL="https://repo.anaconda.com"
 
 export SERIAL_CC=gcc
 export SERIAL_CXX=g++

--- a/config/config_hera_gnu.sh
+++ b/config/config_hera_gnu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="gnu/9.2.0"
+export HPC_MPI="openmpi/3.1.4"
+export HPC_PYTHON="miniconda3/4.6.14"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=Y
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv --no-check-certificate"
+export VENVTYPE="condaenv"
+
+# Load these basic modules for Hera
+module purge
+module load gnu/9.2.0
+module load cmake/3.20.1
+module load openmpi/3.1.4
+
+# gfortran-10 compatibility flags for incompatible software
+#export STACK_esmf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+#export STACK_pnetcdf_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+#export STACK_madis_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+#export STACK_fms_FFLAGS="-march=core-avx2 -fallow-argument-mismatch"
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+# Miniconda3 URL on Hera
+export STACK_miniconda3_URL="http://anaconda.rdhpcs.noaa.gov"
+
+export SERIAL_CC=gcc
+export SERIAL_CXX=g++
+export SERIAL_FC=gfortran
+
+export MPI_CC=mpicc 
+export MPI_CXX=mpicxx
+export MPI_FC=mpifort
+

--- a/config/config_hera_gnu.sh
+++ b/config/config_hera_gnu.sh
@@ -41,6 +41,8 @@ export FC=gfortran
 
 # Miniconda3 URL on Hera
 export STACK_miniconda3_URL="https://repo.anaconda.com"
+# Madis, wgrib2, boost - tar files from github
+export STACK_git_url="https://github.com/natalie-perlin/HPC-stack-NOAA-blocked-downloads/blob/main/"
 
 export SERIAL_CC=gcc
 export SERIAL_CXX=g++

--- a/config/config_jet_gnu.sh
+++ b/config/config_jet_gnu.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="gnu/9.2.0"
+export HPC_MPI="openmpi/3.1.4"
+export HPC_PYTHON="python/3.6.8"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=4
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv --no-check-certificate"
+
+# Bypass unused variable bug in LMod version on Jet when sourcing the LMod setup
+export __lmod_vx=""
+
+# Load these basic modules for Hera
+module purge
+module load gnu/9.2.0
+module load cmake/3.20.1
+module load openmpi/3.1.4
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+export SERIAL_CC=gcc
+export SERIAL_CXX=g++
+export SERIAL_FC=gfortran
+
+export MPI_CC=mpicc
+export MPI_CXX=mpicxx
+export MPI_FC=mpifort

--- a/config/config_jet_gnu.sh
+++ b/config/config_jet_gnu.sh
@@ -26,6 +26,11 @@ module purge
 module load gnu/9.2.0
 module load cmake/3.20.1
 module load openmpi/3.1.4
+# Use alternative URL to download tar files
+# Miniconda3 URL 
+export STACK_miniconda3_URL="https://repo.anaconda.com"
+# Madis, wgrib2, boost - tar files from github
+export STACK_git_URL="https://github.com/natalie-perlin/HPC-stack-NOAA-blocked-downloads/blob/main"
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
 export STACK_fms_FFLAGS="-march=core-avx2"

--- a/config/config_linux_gnu.sh
+++ b/config/config_linux_gnu.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Initialize Lmod (customize path, uncomment)
+#export BASH_ENV=$HOME/apps/lmod/lmod/init/profile        
+#source $BASH_ENV
+
+# Compiler/MPI combination
+export HPC_COMPILER="gnu/10.3.0"
+export HPC_MPI="mpich/3.3.2"
+export HPC_PYTHON="python/3.8.10"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=N
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv --no-check-certificate"
+
+# gfortran-10 compatibility flags for incompatible software
+export STACK_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+
+export CC=gcc
+export FC=gfortran
+export CXX=g++
+
+export SERIAL_CC=gcc
+export SERIAL_FC=gfortran
+export SERIAL_CXX=g++

--- a/config/config_mac_gnu.sh
+++ b/config/config_mac_gnu.sh
@@ -4,8 +4,8 @@
 source /usr/local/opt/lmod/init/profile   
 
 # Compiler/MPI combination
-export HPC_COMPILER="gnu/11.2.0_3"
-export HPC_MPI="mpich/3.3.2"
+export HPC_COMPILER="gnu/11.2.0"
+export HPC_MPI="openmpi/4.1.2"
 export HPC_PYTHON="python/3.9.11"
 
 # Build options

--- a/config/config_mac_m1_gnu.sh
+++ b/config/config_mac_m1_gnu.sh
@@ -4,9 +4,9 @@
 source /opt/homebrew/opt/lmod/init/profile
 
 # Compiler/MPI combination
-export HPC_COMPILER="gnu/11.2.0_3"
+export HPC_COMPILER="gnu/11.2.0"
 export HPC_MPI="openmpi/4.1.2"
-export HPC_PYTHON="python/3.10.2"
+export HPC_PYTHON="python/3.8.9"
 
 # Build options
 export USE_SUDO=N

--- a/config/config_orion_gnu.sh
+++ b/config/config_orion_gnu.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export HPC_COMPILER="gcc/10.2.0"
+export HPC_MPI="openmpi/4.0.4"
+export HPC_PYTHON="python/3.9.2"
+
+# Build options
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=log
+export OVERWRITE=N
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=F
+export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv --no-check-certificate"
+export VENVTYPE="condaenv"
+
+# Load these basic modules for Orion
+module purge
+module load gcc/10.2.0
+module load openmpi/4.0.4
+module load cmake/3.22.1
+module load python/3.9.2
+module load git/2.28.0
+module load cdo/1.9.10
+module load geos/3.8.1
+module load sqlite/3.32.3
+module load proj/7.1.0
+
+# gfortran-10 needs the following
+export STACK_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+# Build FMS with AVX2 flags
+export STACK_fms_CFLAGS="-march=core-avx2"
+export STACK_fms_FFLAGS="-march=core-avx2"
+#
+export CC=gcc
+export FC=gfortran
+export CXX=g++
+#
+

--- a/libs/build_boost.sh
+++ b/libs/build_boost.sh
@@ -9,11 +9,20 @@ level=${2:-${STACK_boost_level:-"full"}}
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 software=$name\_$(echo $version | sed 's/\./_/g')
-URL="https://boostorg.jfrog.io/artifactory/main/release/$version/source/$software.tar.gz"
+if [[ -z ${STACK_git_URL-} ]]; then
+  URL="https://boostorg.jfrog.io/artifactory/main/release/$version/source/$software.tar.gz"
+  [[ -f $software.tar.gz ]] || ( $WGET $URL )
+  software0=$software.tar.gz
+else
+  software0="$software.tar.bz2"
+  URL=${STACK_git_URL}/$software0
+  [[ -f $software0 ]] || ( $WGET "${URL}?raw=true" )
+  [[ -f $software0 ]] || ( mv "$software0?raw=true" $software0 )
+fi
 
-[[ -d $software ]] || $WGET $URL
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
-[[ -d $software ]] || tar -xf $software.tar.gz
+
+[[ -d $software ]] || tar -xf $software0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 ########################################################################

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -167,6 +167,7 @@ else
     export ESMF_OPTLEVEL="2"
   fi
 fi
+[[ "$STACK_esmf_os" == "Linux" ]] && export ESMF_OS="Linux"
 
 export ESMF_INSTALL_PREFIX=$prefix
 export ESMF_INSTALL_BINDIR=bin
@@ -174,6 +175,7 @@ export ESMF_INSTALL_LIBDIR=lib
 export ESMF_INSTALL_MODDIR=mod
 export ESMF_INSTALL_HEADERDIR=include
 [[ $enable_shared =~ [yYtT] ]] || export ESMF_SHARED_LIB_BUILD=OFF
+
 
 make info
 make -j${NTHREADS:-4}

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -21,7 +21,10 @@ abi64=$(uname -m)
 [[ $STACK_esmf_enable_pnetcdf =~ [yYtT] ]] && enable_pnetcdf=YES || enable_pnetcdf=NO
 [[ ${STACK_esmf_shared} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
 [[ ${STACK_esmf_debug} =~ [yYtT] ]] && enable_debug=YES || enable_debug=NO
-
+if  [[ -n ${STACK_esmf_os-} ]]; then
+  [[ ${STACK_esmf_os} == "Linux" ]] && export ESMF_OS="Linux"
+  echo "STACK_esmf_os = $STACK_esmf_os"
+fi
 # This will allow debug version of software (ESMF) to be installed next to the optimized version (this is only affected for $MODULES)
 [[ $enable_debug =~ [yYtT] ]] && version_install=${install_as}-debug || version_install=${install_as}
 
@@ -167,7 +170,6 @@ else
     export ESMF_OPTLEVEL="2"
   fi
 fi
-[[ "$STACK_esmf_os" == "Linux" ]] && export ESMF_OS="Linux"
 
 export ESMF_INSTALL_PREFIX=$prefix
 export ESMF_INSTALL_BINDIR=bin

--- a/libs/build_geos.sh
+++ b/libs/build_geos.sh
@@ -44,9 +44,10 @@ export CXXFLAGS="${STACK_CXXFLAGS:-} ${STACK_hdf5_CXXFLAGS:-} -fPIC -w"
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 software=$name-$version
-URL="https://download.osgeo.org/geos/$software.tar.bz2"
+#URL="https://download.osgeo.org/geos/$software.tar.bz2"
+URL="https://github.com/libgeos/geos.git"
 
-[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.bz2 )
+[[ -d $software ]] || ( git clone -b "$version" $URL $software )
 [[ ${DOWNLOAD_ONLY:-} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 

--- a/libs/build_madis.sh
+++ b/libs/build_madis.sh
@@ -12,8 +12,15 @@ mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 software=$name-$version
-URL="https://madis-data.ncep.noaa.gov/source/$software.tar.gz"
-[[ -f $software.tar.gz ]] || ( $WGET $URL )
+if [[ -z ${STACK_git_URL-} ]]; then
+  URL="https://madis-data.ncep.noaa.gov/source/$software.tar.gz"
+  [[ -f $software.tar.gz ]] || ( $WGET $URL )
+else
+  URL=${STACK_git_URL}/$software.tar.gz
+  [[ -f $software.tar.gz ]] || ( $WGET "${URL}?raw=true" )
+  [[ -f $software.tar.gz ]] ||  mv "$software.tar.gz?raw=true" $software.tar.gz
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
 if $MODULES; then

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -89,7 +89,7 @@ if $MODULES; then
       module try-load jpeg
       module try-load jasper
       module try-load zlib
-      module try-load libpng
+      module try-load png
       module load netcdf
       module load sp
       module load ip2
@@ -103,12 +103,13 @@ if $MODULES; then
       ;;
     g2)
       module try-load jpeg
-      module try-load libpng
+      module try-load png
       module try-load jasper
       ;;
     g2c)
       module try-load jpeg
       module try-load zlib
+      module try-load png
       module try-load libpng
       module try-load jasper
       ;;
@@ -132,8 +133,8 @@ if $MODULES; then
       module try-load jpeg
       module try-load jasper
       module try-load zlib
-      module try-load libpng
-      module try-load w3emc/2.9.2
+      module try-load png
+      module try-load w3emc/2.7.3
       module load bacio
       module load w3nco
       module load g2

--- a/libs/build_png.sh
+++ b/libs/build_png.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -eux
+
+name="png"
+version=${1:-${STACK_png_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+
+[[ ${STACK_png_shared:-} =~ [yYtT] ]] && enable_shared=YES || enable_shared=NO
+
+# manage package dependencies here
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module load hpc-$HPC_COMPILER
+    module load zlib
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+    if [[ -d $prefix ]]; then
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
+    fi
+
+else
+    prefix=${PNG_ROOT:-"/usr/local"}
+fi
+
+export CC=$SERIAL_CC
+export CFLAGS="${STACK_CFLAGS:-} ${STACK_png_CFLAGS:-} -fPIC"
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+URL="https://github.com/glennrp/libpng"
+[[ -d $software ]] || ( git clone -b "v$version" $URL $software )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+sourceDir=$PWD
+[[ -d build ]] && rm -rf build
+mkdir -p build && cd build
+
+[[ $enable_shared =~ [yYtT] ]] && shared_flags="" || shared_flags="-DPNG_SHARED=OFF"
+
+cmake $sourceDir \
+  -DCMAKE_INSTALL_PREFIX=$prefix \
+  -DCMAKE_BUILD_TYPE=RELEASE \
+  -DZLIB_ROOT=${ZLIB_ROOT} \
+  $shared_flags
+
+make -j${NTHREADS:-4}
+[[ $MAKE_CHECK =~ [yYtT] ]] && make test
+$SUDO make install
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $version
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_upp.sh
+++ b/libs/build_upp.sh
@@ -17,7 +17,7 @@ if $MODULES; then
   module load hpc-$HPC_COMPILER
   module load hpc-$HPC_MPI
   module try-load cmake
-  module try-load libpng
+  module try-load png
   module try-load jasper
   module load netcdf
   module load bacio

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -37,13 +37,21 @@ export CXX=$SERIAL_CXX
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
-URL="https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v${version}"
-
-[[ -d $software ]] || ( $WGET $URL; tar -xf wgrib2.tgz.v${version} )
+ 
+if [[ ! -d $software ]]; then
+  if [[ -z ${STACK_git_URL-} ]]; then
+    URL="https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v${version}"
+    $WGET $URL
+  else
+    URL=${STACK_git_URL-}
+    [[ ! -f "wgrib2.tgz.v${version}" ]] && $WGET "${URL}/wgrib2.tgz.v${version}?raw=true"
+    [[ ! -f "wgrib2.tgz.v${version}" ]] && mv "wgrib2.tgz.v${version}?raw=true" "wgrib2.tgz.v${version}"
+  fi
+  tar -xf wgrib2.tgz.v${version} 
 # wgrib2 is untarred as 'grib2'. Give a name with version.
-[[ -d $software ]] || mkdir $software && tar -xf wgrib2.tgz.v${version} -C $software --strip-components 1
+  mkdir $software && tar -xf wgrib2.tgz.v${version} -C $software --strip-components 1
+fi
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
-
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 # The Jasper inside of wgrib2 does not build with Clang on macOS

--- a/modulefiles/compiler/compilerName/compilerVersion/nemsio/nemsio.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nemsio/nemsio.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-depends_on("bacio", "w3emc")
+depends_on("bacio", "w3nco")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/modulefiles/compiler/compilerName/compilerVersion/png/png.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/png/png.lua
@@ -1,0 +1,32 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("MANPATH", pathJoin(base,"share","man"))
+
+setenv("PNG_ROOT", base)
+setenv("PNG_LIB", pathJoin(base,"${CMAKE_INSTALL_LIBDIR}","libpng.a"))
+setenv("PNG_INCLUDES", pathJoin(base,"include"))
+setenv("PNG_LIBRARIES", pathJoin(base,"lib"))
+setenv("PNG_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: PNG library")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsio/nemsio.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nemsio/nemsio.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-depends_on("bacio", "w3emc")
+depends_on("bacio", "w3nco")
 
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 

--- a/stack/stack_gaea_gnu.yaml
+++ b/stack/stack_gaea_gnu.yaml
@@ -1,0 +1,358 @@
+gnu:
+  build: NO
+  version: 11.2.0
+
+mpi:
+  build: YES
+  flavor: openmpi
+  version: 4.1.2
+
+cmake:
+  build: NO
+  bootstrap: YES
+  version: 3.20.1
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.25
+
+sqlite:
+  build: NO 
+  version: 3.32.3
+
+libtiff:
+  build: NO
+  version: 4.0.3
+
+udunits:
+  build: YES
+  version: 2.2.28
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.4
+  version_cxx: 4.3.1
+  disable_cxx: YES
+
+nccmp:
+  build: YES
+  version: 1.8.9.0
+
+nco:
+  build: YES
+  version: 5.0.6
+
+cdo:
+  build: NO 
+  version: 1.9.8
+
+pio:
+  build: YES
+  version: 2.5.2
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: ESMF_8_2_0
+  install_as: 8_2_0
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: YES
+  version: 2021.03
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+  is_nceplib: YES
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip2:
+  build: YES
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+  is_nceplib: YES
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  is_nceplib: YES
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+  is_nceplib: YES
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+  is_nceplib: YES
+
+g2:
+  build: YES
+  version: v3.4.3
+  install_as: 3.4.3
+  is_nceplib: YES
+
+g2c:
+  build: YES
+  version: v1.6.4
+  install_as: 1.6.4
+  is_nceplib: YES
+
+g2tmpl:
+  build: YES
+  version: v1.10.0
+  install_as: 1.10.0
+  is_nceplib: YES
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+  is_nceplib: YES
+  install_fix: NO
+
+upp:
+  build: YES
+  version: upp_v10.0.10
+  install_as: 10.0.10
+  openmp: ON
+  is_nceplib: NO
+
+wrf_io:
+  build: YES
+  version: v1.2.0
+  install_as: 1.2.0
+  openmp: ON
+  is_nceplib: YES
+
+bufr:
+  build: YES
+  version: bufr_v11.5.0
+  install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
+
+wgrib2:
+  build: YES
+  version: 2.0.8
+  install_as: 2.0.8
+  lib: YES
+  ipolates: 3
+
+prod_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  is_nceplib: YES
+
+grib_util:
+  build: YES
+  version: v1.2.3
+  install_as: 1.2.3
+  openmp: ON
+  is_nceplib: YES
+
+ncio:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: YES
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: YES
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: YES
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: YES
+  version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.3
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.11.0
+
+geos:
+  build: YES
+  version: 3.8.1
+
+proj:
+  build: NO 
+  version: 7.1.0
+  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
+
+miniconda3:
+  build: NO
+  version: 4.6.14
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES

--- a/stack/stack_hera_gnu.yaml
+++ b/stack/stack_hera_gnu.yaml
@@ -245,7 +245,7 @@ ncio:
   is_nceplib: YES
 
 boost:
-  build: YES
+  build: NO
   version: 1.68.0
   level: headers-only
 

--- a/stack/stack_hera_gnu.yaml
+++ b/stack/stack_hera_gnu.yaml
@@ -306,7 +306,7 @@ atlas:
   repo: ecmwf
 
 madis:
-  build: YES
+  build: NO
   version: 4.3
 
 esma_cmake:
@@ -344,7 +344,7 @@ proj:
   cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
 
 miniconda3:
-  build: NO
+  build: YES
   version: 4.6.14
 
 r2d2:

--- a/stack/stack_hera_gnu.yaml
+++ b/stack/stack_hera_gnu.yaml
@@ -1,0 +1,358 @@
+gnu:
+  build: NO
+  version: 10.3.0
+
+mpi:
+  build: NO
+  flavor: openmpi
+  version: 4.1.2
+
+cmake:
+  build: NO
+  bootstrap: YES
+  version: 3.20.1
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.25
+
+sqlite:
+  build: NO 
+  version: 3.32.3
+
+libtiff:
+  build: NO
+  version: 4.0.3
+
+udunits:
+  build: YES
+  version: 2.2.28
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.4
+  version_cxx: 4.3.1
+  disable_cxx: YES
+
+nccmp:
+  build: YES
+  version: 1.8.9.0
+
+nco:
+  build: YES
+  version: 5.0.6
+
+cdo:
+  build: NO 
+  version: 1.9.8
+
+pio:
+  build: YES
+  version: 2.5.2
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: ESMF_8_2_0
+  install_as: 8_2_0
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: YES
+  version: 2021.03
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+  is_nceplib: YES
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip2:
+  build: YES
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+  is_nceplib: YES
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  is_nceplib: YES
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+  is_nceplib: YES
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+  is_nceplib: YES
+
+g2:
+  build: YES
+  version: v3.4.3
+  install_as: 3.4.3
+  is_nceplib: YES
+
+g2c:
+  build: YES
+  version: v1.6.4
+  install_as: 1.6.4
+  is_nceplib: YES
+
+g2tmpl:
+  build: YES
+  version: v1.10.0
+  install_as: 1.10.0
+  is_nceplib: YES
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+  is_nceplib: YES
+  install_fix: NO
+
+upp:
+  build: YES
+  version: upp_v10.0.10
+  install_as: 10.0.10
+  openmp: ON
+  is_nceplib: NO
+
+wrf_io:
+  build: YES
+  version: v1.2.0
+  install_as: 1.2.0
+  openmp: ON
+  is_nceplib: YES
+
+bufr:
+  build: YES
+  version: bufr_v11.5.0
+  install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
+
+wgrib2:
+  build: YES
+  version: 2.0.8
+  install_as: 2.0.8
+  lib: YES
+  ipolates: 3
+
+prod_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  is_nceplib: YES
+
+grib_util:
+  build: YES
+  version: v1.2.3
+  install_as: 1.2.3
+  openmp: ON
+  is_nceplib: YES
+
+ncio:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: YES
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: YES
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: YES
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: YES
+  version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.3
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.11.0
+
+geos:
+  build: YES
+  version: 3.8.1
+
+proj:
+  build: NO 
+  version: 7.1.0
+  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
+
+miniconda3:
+  build: NO
+  version: 4.6.14
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES

--- a/stack/stack_hera_gnu.yaml
+++ b/stack/stack_hera_gnu.yaml
@@ -1,11 +1,11 @@
 gnu:
   build: NO
-  version: 10.3.0
+  version: 9.2.0
 
 mpi:
   build: NO
   flavor: openmpi
-  version: 4.1.2
+  version: 3.1.4
 
 cmake:
   build: NO
@@ -245,7 +245,7 @@ ncio:
   is_nceplib: YES
 
 boost:
-  build: NO
+  build: YES
   version: 1.68.0
   level: headers-only
 
@@ -306,7 +306,7 @@ atlas:
   repo: ecmwf
 
 madis:
-  build: NO
+  build: YES
   version: 4.3
 
 esma_cmake:

--- a/stack/stack_jet_gnu.yaml
+++ b/stack/stack_jet_gnu.yaml
@@ -1,0 +1,358 @@
+gnu:
+  build: NO
+  version: 10.3.0
+
+mpi:
+  build: NO
+  flavor: openmpi
+  version: 4.1.2
+
+cmake:
+  build: NO
+  bootstrap: YES
+  version: 3.20.1
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.25
+
+sqlite:
+  build: NO 
+  version: 3.32.3
+
+libtiff:
+  build: NO
+  version: 4.0.3
+
+udunits:
+  build: YES
+  version: 2.2.28
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.4
+  version_cxx: 4.3.1
+  disable_cxx: YES
+
+nccmp:
+  build: YES
+  version: 1.8.9.0
+
+nco:
+  build: YES
+  version: 5.0.6
+
+cdo:
+  build: NO 
+  version: 1.9.8
+
+pio:
+  build: YES
+  version: 2.5.2
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: ESMF_8_2_0
+  install_as: 8_2_0
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: YES
+  version: 2021.03
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+  is_nceplib: YES
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip2:
+  build: YES
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+  is_nceplib: YES
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  is_nceplib: YES
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+  is_nceplib: YES
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+  is_nceplib: YES
+
+g2:
+  build: YES
+  version: v3.4.3
+  install_as: 3.4.3
+  is_nceplib: YES
+
+g2c:
+  build: YES
+  version: v1.6.4
+  install_as: 1.6.4
+  is_nceplib: YES
+
+g2tmpl:
+  build: YES
+  version: v1.10.0
+  install_as: 1.10.0
+  is_nceplib: YES
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+  is_nceplib: YES
+  install_fix: NO
+
+upp:
+  build: YES
+  version: upp_v10.0.10
+  install_as: 10.0.10
+  openmp: ON
+  is_nceplib: NO
+
+wrf_io:
+  build: YES
+  version: v1.2.0
+  install_as: 1.2.0
+  openmp: ON
+  is_nceplib: YES
+
+bufr:
+  build: NO
+  version: bufr_v11.5.0
+  install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
+
+wgrib2:
+  build: YES
+  version: 2.0.8
+  install_as: 2.0.8
+  lib: YES
+  ipolates: 3
+
+prod_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  is_nceplib: YES
+
+grib_util:
+  build: YES
+  version: v1.2.3
+  install_as: 1.2.3
+  openmp: ON
+  is_nceplib: YES
+
+ncio:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: NO
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: YES
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: YES
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: NO
+  version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.3
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.11.0
+
+geos:
+  build: YES
+  version: 3.8.1
+
+proj:
+  build: NO 
+  version: 7.1.0
+  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
+
+miniconda3:
+  build: NO
+  version: 4.6.14
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES

--- a/stack/stack_jet_gnu.yaml
+++ b/stack/stack_jet_gnu.yaml
@@ -245,7 +245,7 @@ ncio:
   is_nceplib: YES
 
 boost:
-  build: NO
+  build: YES
   version: 1.68.0
   level: headers-only
 
@@ -306,7 +306,7 @@ atlas:
   repo: ecmwf
 
 madis:
-  build: NO
+  build: YES
   version: 4.3
 
 esma_cmake:
@@ -344,7 +344,7 @@ proj:
   cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
 
 miniconda3:
-  build: NO
+  build: YES
   version: 4.6.14
 
 r2d2:

--- a/stack/stack_linux_gnu.yaml
+++ b/stack/stack_linux_gnu.yaml
@@ -1,0 +1,358 @@
+gnu:
+  build: NO
+  version: 10.3.0
+
+mpi:
+  build: NO
+  flavor: mpich
+  version: 3.3.2
+
+cmake:
+  build: NO
+  bootstrap: YES
+  version: 3.20.1
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.25
+
+sqlite:
+  build: NO 
+  version: 3.32.3
+
+libtiff:
+  build: NO
+  version: 4.0.3
+
+udunits:
+  build: YES
+  version: 2.2.28
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.4
+  version_cxx: 4.3.1
+  disable_cxx: YES
+
+nccmp:
+  build: YES
+  version: 1.8.9.0
+
+nco:
+  build: YES
+  version: 5.0.6
+
+cdo:
+  build: NO 
+  version: 1.9.8
+
+pio:
+  build: YES
+  version: 2.5.2
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: ESMF_8_2_0
+  install_as: 8_2_0
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: YES
+  version: 2021.03
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+  is_nceplib: YES
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip2:
+  build: YES
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+  is_nceplib: YES
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  is_nceplib: YES
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+  is_nceplib: YES
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+  is_nceplib: YES
+
+g2:
+  build: YES
+  version: v3.4.3
+  install_as: 3.4.3
+  is_nceplib: YES
+
+g2c:
+  build: YES
+  version: v1.6.4
+  install_as: 1.6.4
+  is_nceplib: YES
+
+g2tmpl:
+  build: YES
+  version: v1.10.0
+  install_as: 1.10.0
+  is_nceplib: YES
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+  is_nceplib: YES
+  install_fix: NO
+
+upp:
+  build: YES
+  version: upp_v10.0.10
+  install_as: 10.0.10
+  openmp: ON
+  is_nceplib: NO
+
+wrf_io:
+  build: YES
+  version: v1.2.0
+  install_as: 1.2.0
+  openmp: ON
+  is_nceplib: YES
+
+bufr:
+  build: YES
+  version: bufr_v11.5.0
+  install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
+
+wgrib2:
+  build: YES
+  version: 2.0.8
+  install_as: 2.0.8
+  lib: YES
+  ipolates: 3
+
+prod_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  is_nceplib: YES
+
+grib_util:
+  build: YES
+  version: v1.2.3
+  install_as: 1.2.3
+  openmp: ON
+  is_nceplib: YES
+
+ncio:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: NO
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: YES
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: YES
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: NO
+  version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.3
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.11.0
+
+geos:
+  build: YES
+  version: 3.8.1
+
+proj:
+  build: NO 
+  version: 7.1.0
+  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
+
+miniconda3:
+  build: YES
+  version: 4.6.14
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -1,11 +1,11 @@
 gnu:
-  build: YES
-  version: 11.2.0_3
+  build: NO
+  version: 11.2.0
 
 mpi:
   build: YES
-  flavor: mpich
-  version: 3.3.2
+  flavor: openmpi
+  version: 4.1.2
 
 cmake:
   build: NO
@@ -20,9 +20,9 @@ zlib:
   build: YES
   version: 1.2.11
 
-libpng:
+png:
   build: NO
-  version: 1.6.37
+  version: 1.6.35
 
 szip:
   build: YES
@@ -59,7 +59,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.9.1.0
+  version: 1.8.9.0
 
 nco:
   build: YES
@@ -78,14 +78,14 @@ pio:
 esmf:
   build: YES
   version: ESMF_8_2_0
-  install_as: 8.2.0
+  install_as: 8_2_0
   shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
   build: YES
-  version: 2021.03
+  version: 2021.04
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DENABLE_QUAD_PRECISION=OFF "
 
@@ -148,8 +148,8 @@ landsfcutil:
 
 nemsio:
   build: YES
-  version: v2.5.4
-  install_as: 2.5.4
+  version: v2.5.2
+  install_as: 2.5.2
   is_nceplib: YES
 
 nemsiogfs:
@@ -160,8 +160,8 @@ nemsiogfs:
 
 w3emc:
   build: YES
-  version: v2.9.2
-  install_as: 2.9.2
+  version: v2.7.3
+  install_as: 2.7.3
   is_nceplib: YES
 
 g2:
@@ -191,8 +191,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.9
-  install_as: 10.0.9
+  version: upp_v10.0.10
+  install_as: 10.0.10
   openmp: ON
 
 wrf_io:
@@ -224,15 +224,15 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.4
-  install_as: 1.2.4
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 
 ncio:
   build: YES
-  version: v1.1.0
-  install_as: 1.1.0
+  version: v1.0.0
+  install_as: 1.0.0
   is_nceplib: YES
 
 boost:
@@ -299,7 +299,6 @@ atlas:
 madis:
   build: YES
   version: 4.3
-  STACK_madis_FFLAGS=" -fallow-argument-mismatch -fallow-invalid-boz"
 
 esma_cmake:
   build: YES
@@ -325,7 +324,6 @@ mapl:
   build: YES
   repo: GEOS-ESM
   version: v2.12.2
-  esmf_version: 8.2.0
 
 geos:
   build: YES

--- a/stack/stack_mac_gnu.yaml
+++ b/stack/stack_mac_gnu.yaml
@@ -1,11 +1,11 @@
 gnu:
   build: NO
-  version: 11.2.0_3
+  version: 11.2.0
 
 mpi:
   build: YES
-  flavor: mpich
-  version: 3.3.2
+  flavor: openmpi
+  version: 4.1.2
 
 cmake:
   build: NO
@@ -20,9 +20,9 @@ zlib:
   build: YES
   version: 1.2.11
 
-libpng:
+png:
   build: NO
-  version: 1.6.37
+  version: 1.6.35
 
 szip:
   build: YES
@@ -78,7 +78,7 @@ pio:
 esmf:
   build: YES
   version: ESMF_8_2_0
-  install_as: 8.2.0
+  install_as: 8_2_0
   shared: YES
   enable_pnetcdf: NO
   debug: NO
@@ -148,8 +148,8 @@ landsfcutil:
 
 nemsio:
   build: YES
-  version: v2.5.4
-  install_as: 2.5.4
+  version: v2.5.2
+  install_as: 2.5.2
   is_nceplib: YES
 
 nemsiogfs:
@@ -160,8 +160,8 @@ nemsiogfs:
 
 w3emc:
   build: YES
-  version: v2.9.2
-  install_as: 2.9.2
+  version: v2.7.3
+  install_as: 2.7.3
   is_nceplib: YES
 
 g2:
@@ -191,8 +191,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.9
-  install_as: 10.0.9
+  version: upp_v10.0.10
+  install_as: 10.0.10
   openmp: ON
 
 wrf_io:
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.4
-  install_as: 1.2.4
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_mac_m1_gnu.yaml
+++ b/stack/stack_mac_m1_gnu.yaml
@@ -1,6 +1,6 @@
 gnu:
   build: NO
-  version: 11.2.0_3
+  version: 11.2.0
 
 mpi:
   build: YES
@@ -20,9 +20,9 @@ zlib:
   build: YES
   version: 1.2.11
 
-libpng:
+png:
   build: NO
-  version: 1.6.37
+  version: 1.6.35
 
 szip:
   build: YES
@@ -78,7 +78,7 @@ pio:
 esmf:
   build: YES
   version: ESMF_8_2_0
-  install_as: 8.2.0
+  install_as: 8_2_0
   shared: YES
   enable_pnetcdf: NO
   debug: NO
@@ -148,8 +148,8 @@ landsfcutil:
 
 nemsio:
   build: YES
-  version: v2.5.4
-  install_as: 2.5.4
+  version: v2.5.2
+  install_as: 2.5.2
   is_nceplib: YES
 
 nemsiogfs:
@@ -160,8 +160,8 @@ nemsiogfs:
 
 w3emc:
   build: YES
-  version: v2.9.2
-  install_as: 2.9.2
+  version: v2.7.3
+  install_as: 2.7.3
   is_nceplib: YES
 
 g2:
@@ -191,8 +191,8 @@ crtm:
 
 upp:
   build: YES
-  version: upp_v10.0.9
-  install_as: 10.0.9
+  version: upp_v10.0.10
+  install_as: 10.0.10
   openmp: ON
 
 wrf_io:
@@ -224,8 +224,8 @@ prod_util:
 
 grib_util:
   build: YES
-  version: v1.2.4
-  install_as: 1.2.4
+  version: v1.2.3
+  install_as: 1.2.3
   openmp: ON
   is_nceplib: YES
 

--- a/stack/stack_orion_gnu.yaml
+++ b/stack/stack_orion_gnu.yaml
@@ -1,0 +1,358 @@
+gnu:
+  build: NO
+  version: 10.2.0
+
+mpi:
+  build: NO
+  flavor: openmpi
+  version: 4.0.4
+
+cmake:
+  build: NO
+  bootstrap: YES
+  version: 3.20.1
+
+jpeg:
+  build: YES
+  version: 9.1.0
+
+zlib:
+  build: YES
+  version: 1.2.11
+
+png:
+  build: YES
+  version: 1.6.35
+
+szip:
+  build: YES
+  version: 2.1.1
+
+jasper:
+  build: YES
+  version: 2.0.25
+
+sqlite:
+  build: NO 
+  version: 3.32.3
+
+libtiff:
+  build: NO
+  version: 4.0.3
+
+udunits:
+  build: YES
+  version: 2.2.28
+
+hdf5:
+  build: YES
+  version: 1.10.6
+  shared: YES
+  enable_szip: NO
+  enable_zlib: YES
+
+pnetcdf:
+  build: NO
+  version: 1.12.1
+  shared: YES
+
+netcdf:
+  build: YES
+  shared: YES
+  enable_pnetcdf: NO
+  version_c: 4.7.4
+  version_f: 4.5.4
+  version_cxx: 4.3.1
+  disable_cxx: YES
+
+nccmp:
+  build: YES
+  version: 1.8.9.0
+
+nco:
+  build: YES
+  version: 5.0.6
+
+cdo:
+  build: NO 
+  version: 1.9.8
+
+pio:
+  build: YES
+  version: 2.5.2
+  enable_pnetcdf: NO
+  enable_gptl: NO
+
+esmf:
+  build: YES
+  version: ESMF_8_2_0
+  install_as: 8_2_0
+  shared: YES
+  enable_pnetcdf: NO
+  debug: NO
+
+fms:
+  build: YES
+  version: 2021.03
+  repo: noaa-gfdl
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+
+bacio:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sigio:
+  build: YES
+  version: v2.3.2
+  install_as: 2.3.2
+  is_nceplib: YES
+
+sfcio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+gfsio:
+  build: YES
+  version: v1.4.1
+  install_as: 1.4.1
+  is_nceplib: YES
+
+w3nco:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+sp:
+  build: YES
+  version: v2.3.3
+  install_as: 2.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip:
+  build: YES
+  version: v3.3.3
+  install_as: 3.3.3
+  openmp: ON
+  is_nceplib: YES
+
+ip2:
+  build: YES
+  version: v1.1.2
+  install_as: 1.1.2
+  openmp: ON
+  is_nceplib: YES
+
+landsfcutil:
+  build: YES
+  version: v2.4.1
+  install_as: 2.4.1
+  is_nceplib: YES
+
+nemsio:
+  build: YES
+  version: v2.5.2
+  install_as: 2.5.2
+  is_nceplib: YES
+
+nemsiogfs:
+  build: YES
+  version: v2.5.3
+  install_as: 2.5.3
+  is_nceplib: YES
+
+w3emc:
+  build: YES
+  version: v2.7.3
+  install_as: 2.7.3
+  is_nceplib: YES
+
+g2:
+  build: YES
+  version: v3.4.3
+  install_as: 3.4.3
+  is_nceplib: YES
+
+g2c:
+  build: YES
+  version: v1.6.4
+  install_as: 1.6.4
+  is_nceplib: YES
+
+g2tmpl:
+  build: YES
+  version: v1.10.0
+  install_as: 1.10.0
+  is_nceplib: YES
+
+crtm:
+  build: YES
+  version: v2.3.0
+  install_as: 2.3.0
+  is_nceplib: YES
+  install_fix: NO
+
+upp:
+  build: YES
+  version: upp_v10.0.10
+  install_as: 10.0.10
+  openmp: ON
+  is_nceplib: NO
+
+wrf_io:
+  build: YES
+  version: v1.2.0
+  install_as: 1.2.0
+  openmp: ON
+  is_nceplib: YES
+
+bufr:
+  build: YES
+  version: bufr_v11.5.0
+  install_as: 11.5.0
+  python: YES
+  is_nceplib: YES
+
+wgrib2:
+  build: YES
+  version: 2.0.8
+  install_as: 2.0.8
+  lib: YES
+  ipolates: 3
+
+prod_util:
+  build: YES
+  version: v1.2.2
+  install_as: 1.2.2
+  is_nceplib: YES
+
+grib_util:
+  build: YES
+  version: v1.2.3
+  install_as: 1.2.3
+  openmp: ON
+  is_nceplib: YES
+
+ncio:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
+boost:
+  build: YES
+  version: 1.68.0
+  level: headers-only
+
+eigen:
+  build: YES
+  version: 3.3.7
+
+gsl_lite:
+  build: YES
+  version: 0.37.0
+
+gptl:
+  build: NO
+  version: 8.0.2
+
+fftw:
+  build: NO
+  version: 3.3.8
+
+tau2:
+  build: NO
+  version: 3.25.1
+
+cgal:
+  build: NO
+  version: 5.0.2
+
+json:
+  build: YES
+  version: 3.9.1
+
+json_schema_validator:
+  build: YES
+  version: 2.1.0
+
+pybind11:
+  build: YES
+  version: 2.5.0
+
+ecbuild:
+  build: YES
+  version: 3.6.1
+  repo: ecmwf
+
+eckit:
+  build: YES
+  version: 1.16.0
+  repo: ecmwf
+
+fckit:
+  build: YES
+  version: 0.9.2
+  repo: ecmwf
+
+atlas:
+  build: YES
+  version: 0.24.1
+  repo: ecmwf
+
+madis:
+  build: YES
+  version: 4.3
+
+esma_cmake:
+  build: YES
+  repo: GEOS-ESM
+  version: v3.4.3
+
+cmakemodules:
+  build: YES
+  repo: NOAA-EMC
+  version: v1.2.0
+
+gftl_shared:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v1.3.3
+
+yafyaml:
+  build: YES
+  repo: Goddard-Fortran-Ecosystem
+  version: v0.5.1
+
+mapl:
+  build: YES
+  repo: GEOS-ESM
+  version: v2.11.0
+
+geos:
+  build: YES
+  version: 3.8.1
+
+proj:
+  build: NO 
+  version: 7.1.0
+  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
+
+miniconda3:
+  build: NO
+  version: 4.6.14
+
+r2d2:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES
+
+ufswm:
+  build: NO
+  version: 1.0.0
+  is_pyvenv: YES


### PR DESCRIPTION
HPC-stack libraries built for the SRW app: ufs-srweather-app release/public-v2 ,
using GNU compilers (GNU10.2 or 9.2) and openmpi, on Orion, Gaea, Hera, Jet.

Notes:
Gaea

library geos is downloaded from github, repo: https://github.com/libgeos/geos.git
Hera

building anaconda downloaded from another source (not NOAA)
turned off building: madis , boost
Jet

turned off building: bufr
still problem with downloadig wgib2.
(possible solution: download from github? - need to check and possibly modify installation steps, including wgrib2 - grib2 -grib_utils directory name differences)
branch: feature/v2.0.8 repo: https://github.com/NOAA-EMC/NCEPLIBS-wgrib2.git
Use a variable STACK_esmf_os on Gaea, to set ESMF_OS="Linux"