### PR TITLE
Updated documentation for MacOS build of hpc-stack

### DIFF
--- a/docs/source/hpc-components.rst
+++ b/docs/source/hpc-components.rst
@@ -21,6 +21,7 @@ The HPC-Stack packages are built in :numref:`Step %s <NonConHPCBuild>` using the
   * `CMake <https://cmake.org/>`__
   * `Udunits <https://www.unidata.ucar.edu/software/udunits/>`__
   * `PNG <http://www.libpng.org/pub/png/>`__
+  * `TIFF <https://gitlab.com/libtiff/libtiff.git>`__
   * `JPEG <https://jpeg.org/>`__
   * `Jasper <https://github.com/jasper-software/jasper>`__
   * `SZip <https://support.hdfgroup.org/doc_resource/SZIP/>`__
@@ -34,7 +35,6 @@ The HPC-Stack packages are built in :numref:`Step %s <NonConHPCBuild>` using the
   * `CDO <https://code.mpimet.mpg.de/projects/cdo>`__
   * `FFTW <http://www.fftw.org/>`__
   * `GPTL <https://jmrosinski.github.io/GPTL/>`__
-  * Tau2
   * `Boost <https://beta.boost.org/>`__
   * `Eigen <http://eigen.tuxfamily.org/>`__
   * `GSL-Lite <http://github.com/gsl-lite/gsl-lite>`__

--- a/docs/source/hpc-install.rst
+++ b/docs/source/hpc-install.rst
@@ -88,7 +88,7 @@ Build the HPC-Stack
       sed -i "10 a export PATH=/usr/local/sbin:/usr/local/bin:$PATH" ./build_stack.sh
       sed -i "10 a export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH" ./build_stack.sh
 
-#. Build the environment. This may take several hours to complete. 
+#. Build the environment. This may take up to a couple of hours to complete. 
    
    .. code-block:: console
 
@@ -119,7 +119,7 @@ To install the HPC-Stack locally, the following pre-requisites must be installed
 * **Python 3:** Can be obtained either from the `main distributor <https://www.python.org/>`_ or from `Anaconda <https://www.anaconda.com/>`_. 
 * **Compilers:** Distributions of Fortran, C, and C++ compilers that work for your system. 
 * **Message Passing Interface (MPI)** libraries for multi-processor and multi-core communications, configured to work with your corresponding Fortran, C, and C++ compilers. 
-* **Programs and software packages:** `Lmod <https://lmod.readthedocs.io/en/latest/030_installing.html>`_, `CMake <https://cmake.org/install/>`_, `make <https://www.gnu.org/software/make/>`_, `wget <https://www.gnu.org/software/wget/>`_, `curl <https://curl.se/>`_, `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_, and the `TIFF library <https://gitlab.com/libtiff/libtiff.git>`_. 
+* **Programs and software packages:** `Lmod <https://lmod.readthedocs.io/en/latest/030_installing.html>`_, `CMake <https://cmake.org/install/>`_, `make <https://www.gnu.org/software/make/>`_, `wget <https://www.gnu.org/software/wget/>`_, `curl <https://curl.se/>`_, `git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_.
 
 .. note::
    For detailed instructions on how to build the HPC-Stack on two particular configurations of MacOS, see :numref:`Chapter %s <MacInstall>`
@@ -202,22 +202,21 @@ These ``hpc-`` modules are really meta-modules that load the compiler/MPI librar
 
 In short, you may prefer not to load the compiler or MPI modules directly. Instead, loading the hpc- meta-modules as demonstrated above will provide everything needed to load software libraries.
    
-It may be necessary to set certain source and path variables in the ``build_stack.sh`` script. For example:
+It may be necessary to set few environment variables in the ``build_stack.sh`` script. For example:
+r
 
    .. code-block:: console
 
-      source /usr/share/lmod/6.6/init/bash
-      source /usr/share/lmod/lmod/init/bash
       export PATH=/usr/local/sbin:/usr/local/bin:$PATH
       export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH
       export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
-It may also be necessary to initialize ``Lmod`` when using a user-specific ``Lmod`` installation:
+``Lmod`` needs to be initialized based on the installation directory:
 
    .. code-block:: console
 
       module purge
-      export BASH_ENV=$HOME/<Lmod-installation-dir>/lmod/lmod/init/bash 
+      export BASH_ENV=<Lmod-installation-dir>/lmod/lmod/init/profile
       source $BASH_ENV  
       export LMOD_SYSTEM_DEFAULT_MODULES=<module1>:<module2>:<module3>
       module --initial_load --no_redirect restore

--- a/docs/source/hpc-notes.rst
+++ b/docs/source/hpc-notes.rst
@@ -10,11 +10,11 @@ HPC-Stack Additional Notes
 Setting Compiler Flags and Other Options
 -----------------------------------------
 
-Often it is necessary to specify compiler flags (e.g., ``gfortran-10 -fallow-argument-mismatch`` for the packages via ``FFLAGS``.  There are 2 ways this can be achieved:
+Often it is necessary to specify compiler flags (e.g., gfortran-10 requires ``-fallow-argument-mismatch``to be used with ``FFLAGS``.  There are 2 ways this can be achieved:
 
-#. **For all packages:** One can define variable e.g., ``STACK_FFLAGS=-fallow-argument-mismatch`` in the config file ``config_custom.sh``.  This will append ``STACK_FFLAGS`` to ``FFLAGS`` in every build script under libs.
+#. **For all packages:** One can define variable e.g., ``STACK_FFLAGS=-fallow-argument-mismatch`` in the config file ``config_custom.sh``.  This will append ``STACK_FFLAGS`` to ``FFLAGS`` in every build script under ./libs/ directory.
 
-#. **Package specific flags:** To compile only the specific package under ``libs`` with the above compiler flag, one can define variable ``FFLAGS=-fallow-argument-mismatch`` in the ``<package>`` section of the YAML file ``stack_custom.yaml``. This will append ``STACK_<package>_FFLAGS`` to ``FFLAGS`` in the build script for that package only.
+#. **Package-specific flags:** To compile only the specific package under ``libs`` with the above compiler flag, one can define variable ``FFLAGS=-fallow-argument-mismatch`` in the ``<package>`` section of the YAML file ``stack_custom.yaml``. This will append ``STACK_<package>_FFLAGS`` to ``FFLAGS`` in the build script for that package only.
 
 Adding a New Library or Package
 --------------------------------

--- a/docs/source/hpc-parameters.rst
+++ b/docs/source/hpc-parameters.rst
@@ -11,8 +11,9 @@ Compiler & MPI
 ``HPC_COMPILER``: 
    This defines the vendor and version of the compiler you wish to use for this build. The format is the same as what you would typically use in a module load command. For example, ``HPC_COMPILER=intel/2020``. Options include: 
 
-   * ``gnu/6.5.0``
    * ``gnu/9.2.0``
+   * ``gnu/10.1.0``
+   * ``gnu/11.2.0``
    * ``intel/18.0.5.274``
    * ``intel/19.0.5.281``
    * ``intel/2020``
@@ -31,6 +32,7 @@ Compiler & MPI
    * ``impi/2020.2``
    * ``impi/2021.3.0``
    * ``mvapich2/2.3``
+   * ``mpich/3.3.2``
    * ``openmpi/4.1.2``
 
 .. note:: 

--- a/docs/source/hpc-prereqs.rst
+++ b/docs/source/hpc-prereqs.rst
@@ -20,11 +20,20 @@ The following system, compiler, and MPI combinations have been tested successful
    | Linux CentOS 7         | Intel compilers 2020.0  | Intel MPI                   |
    |                        | (ifort, icc, icps)      | (mpiifort, mpiicc, mpiicpc) |
    +------------------------+-------------------------+-----------------------------+
+   | Linux Ubuntu 20.04     | GNU compilers 10.3      | MPICH 3.3.2                 |
+   |                        | (gcc, g++, gfortran)    | (mpifort, mpicc, mpicxx)    |
+   +------------------------+-------------------------+-----------------------------+
+   | MacOS M1/arm64 arch.   | GNU compilers 10.2      | OpenMPI 4.1.2               |
+   |  BigSur / Darwin 20    | (gcc, g++, gfortran)    | (mpifort, mpicc, mpicxx)    |
+   +------------------------+-------------------------+-----------------------------+
+   | MacOS Intel x86_64     | GNU compilers 10.2      | OpenMPI 4.1.2, MPICH 3.3.2  |
+   |  Catalina/Darwin 19    | (gcc, g++, gfortran)    | (mpifort, mpicc, mpicxx)    |  
+   +------------------------+-------------------------+-----------------------------+
 
 Compilers and MPI libraries can be downloaded from the following websites: 
 
 Compilers: 
-  * `GNU/GCC <https://gcc.gnu.org/>`__ (version 9.x)
+  * `GNU/GCC <https://gcc.gnu.org/>`__ (version 11.x)
   * `Intel <https://intel.com/>`__
 
 MPI's

--- a/docs/source/mac-install.rst
+++ b/docs/source/mac-install.rst
@@ -6,9 +6,9 @@ Install and Build HPC-Stack on MacOS
 
 HPC-Stack can be installed and built on MacOS systems. The following two options have been tested:
 
-* **Option 1:** MacBookAir 2020, M1 chip (arm64, running natively), 4+4 cores, Big Sur 11.6.4, GNU compiler suite v.11.2.0_3 (gcc, gfortran, g++); no MPI pre-installed
+* **Option 1:** MacBookAir 2020, M1 chip (arm64, running natively), 4+4 cores, Big Sur 11.6.4, GNU compiler suite v.11.2.0 (gcc, gfortran, g++); no MPI pre-installed
 
-* **Option 2:** MacBook Pro 2015, 2.8 GHz Quad-Core Intel Core i7 (x86_64), Catalina OS X 10.15.7, GNU compiler suite v.11.2.0_3 (gcc, gfortran, g++); no MPI pre-installed
+* **Option 2:** MacBook Pro 2015, 2.8 GHz Quad-Core Intel Core i7 (x86_64), Catalina OS X 10.15.7, GNU compiler suite v.11.2.0 (gcc, gfortran, g++); no MPI pre-installed
 
 .. note::
     Examples throughout this chapter presume that the user is running Terminal.app with a bash shell environment. If this is not the case, users will need to adjust commands to fit their command line application and shell environment. 
@@ -33,10 +33,17 @@ An alternative way to install the Xcode command-line tools (CLT) is as follows:
 
     xcode-select --install 
 
+Note the messages at the end of the installation. Users may need to update the environment variable ``$PATH`` and add it to the shell initialization:
+
+.. code-block:: console
+
+   export PATH=/opt/homebrew/bin:$PATH
+   echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.bashrc
+
 Install Compilers
 ^^^^^^^^^^^^^^^^^^^^^
 
-Install GNU compiler suite (version 11) and gfortran: 
+Install GNU compiler suite (version 11) with gfortran: 
 
 .. code-block:: console
 
@@ -47,14 +54,18 @@ Create symbolic links from the version-specific binaries to gcc and g++.  A ``su
 .. code-block:: console
 
     which gcc-11    
-    cd /usr/local/bin/        (OR cd /opt/homebrew/bin/ )
+    cd /opt/homebrew/bin/    (Version 2: cd /usr/local/bin/) 
     ln -s gcc-11 gcc  
     ln -s g++-11 g++
 
-There is no need to create a link for gfortran if this is the first installation of this compiler. If an earlier version of gfortran exists, you may rename it (e.g., to "gfortran-old") and create a link to the new installation:
+Verify that compiler path installed using homebrew takes precedence over  ``/usr/bin`` path with system compilers: ``echo $PATH``.  
+    
+Check if a previous version of gfortran exists; rename it in that case (e.g., to "gfortran-X") and create a link to a newer binary:
 
 .. code-block:: console
 
+    which gfortran 
+    mv gfortran gfortran-X
     ln -s gfortran-11 gfortran
 
 Verify the paths for the compiler binaries:
@@ -140,14 +151,14 @@ For the Option 1 installation, add:
 
 .. code-block:: console
 
-   export BASH_ENV="/opt/homebrew/opt/lmod/init/bash"
+   export BASH_ENV="/opt/homebrew/opt/lmod/init/profile"
    source $BASH_ENV
 
 For the Option 2 installation, add:
 
 .. code-block:: console
 
-   export BASH_ENV="/usr/local/opt/lmod/init/bash"
+   export BASH_ENV="/usr/local/opt/lmod/init/profile"
    source $BASH_ENV
 
 .. _InstallLibpng:
@@ -155,7 +166,7 @@ For the Option 2 installation, add:
 Install libpng 
 ^^^^^^^^^^^^^^^^^^^
 
-The libpng library has issues when building on MacOS during the HPC-Stack bundle build. Therefore, it must be installed separately. To install the libpng library, run:
+The libpng library has issues when building on MacOS during the HPC-Stack bundle build. Install it separately using homebrew:
 
 .. code-block:: console
 
@@ -185,7 +196,7 @@ First, verify that Python3 is installed, and check the current version:
 
 The first command should return ``/usr/bin/python3`` and the second should return ``Python 3.8.2`` or similar (the exact version is unimportant).
 
-If necessary, download an updated version of Python3 for MacOS from https://www.python.org/downloads. The version 3.9.11 64-bit universal2 installer package is recommended (i.e., ``python-3.9.11-macos11.pkg``). Double-click on the installer package, and accept the license terms. An administrative level password will be requested for the installation. At the end of the installation, run ``Install Certificates.command`` by double-clicking on the shell script in Finder.app that opens and runs it. 
+For Python3 installation and updates on MacOS refer to https://www.python.org/downloads. A 64-bit universal2 installer package is recommended (``python-3.9.11-macos11.pkg`` latest at the time of writing). Double-click on the installer package, and accept the license terms. An administrative level password will be requested for the installation. At the end of the installation, run ``Install Certificates.command`` by double-clicking on the shell script in Finder.app that opens and runs it. 
 
 Start a new bash session (type ``bash`` in the existing terminal), and verify the installed version:
 
@@ -250,9 +261,8 @@ Specify the combination of compilers, python libraries, and MPI libraries in the
 
 .. code-block:: console 
 
-    export HPC_COMPILER="gnu/11.2.0_3"
-    export HPC_MPI="openmpi/4.1.2"      (Option 1 only)  
-    export HPC_MPI="mpich/3.3.2"        (Option 2 only)
+    export HPC_COMPILER="gnu/11.2.0"
+    export HPC_MPI="openmpi/4.1.2" 
     export HPC_PYTHON="python/3.10.2"
 
 Comment out any export statements not relevant to the system, and make sure that version numbers reflect the versions installed on the system (which may differ from the versions listed here). 
@@ -280,7 +290,7 @@ For Option 2:
 Set Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set the environmental variables for compiler paths in ``./config/config_<machine>.sh``. The variable ``GNU`` below refers to the directory where the compiler binaries are located. For example, with Option 1, ``GNU=/opt/homebrew/bin/gcc``, and with Option 2: ``GNU=/usr/local/bin``. 
+Set the environmental variables for compiler paths in ``./config/config_<machine>.sh``. The variable ``GNU`` below refers to the directory where the compiler binaries are located. For example, with Option 1, ``GNU=/opt/homebrew/bin``, and with Option 2: ``GNU=/usr/local/bin``. 
 
 .. code-block:: console 
 
@@ -296,9 +306,7 @@ Set the environmental variables for compiler paths in ``./config/config_<machine
 Specify MPI Libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Specify the MPI libraries to be built within the HPC-Stack in ``./stack/stack_<machine>.yaml``. The ``openmpi/4.1.2`` (Option 1) and ``mpich/3.3.2`` (Option 2) have been built successfully.
-
-Option 1: 
+Specify the MPI libraries to be built within the HPC-Stack in ``./stack/stack_<machine>.yaml``. The ``openmpi/4.1.2`` (Option 1 and Option 2) and ``mpich/3.3.2`` (Option 2) have been built successfully.
 
 .. code-block:: console 
 
@@ -306,15 +314,6 @@ Option 1:
     build: YES
     flavor: openmpi
     version: 4.1.2
-
-Option 2:
-
-.. code-block:: console 
-
-    mpi:
-    build: YES
-    flavor: mpich
-    version: 3.3.2
 
 Libpng
 ^^^^^^^^^
@@ -336,7 +335,7 @@ Set up the modules and environment:
 
     ./setup_modules.sh -c config/config_<machine>.sh -p $HPC_INSTALL_DIR | tee setup_modules.log
 
-where ``<machine>`` is ``mac_m1_gnu`` (Option 1), or ``mac_gnu`` (Option 2), and ``$HPC_INSTALL_DIR`` is the *absolute* path for the installation directory of the HPC-Stack. You will be asked to choose whether or not to use "native" installations of Python, the compilers, and the MPI. "Native" means that they are already installed on your system. Thus, you answer "YES" to python, "YES" to gnu compilers, and "NO" for MPI/mpich. 
+where ``<machine>`` is ``mac_m1_gnu`` (Option 1), or ``mac_gnu`` (Option 2), and ``$HPC_INSTALL_DIR`` is the *absolute* path of the HPC-stack installation directory. When asked whether to use "native" Python or compilers, choose "YES" if using those already installed on your system, or "NO" if they will be built during the HPC-stack installation. The likely response is to answer "YES" to python, "YES" to compilers, and "NO" for MPI/mpich. 
 
 Building HPC-Stack
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated documentation  in ./docs/source/:
 - corrected directions for the MacOS HPC-stack build 
 - removed a library from the list of hpc-stack components that is no longer being built within the stack
 - made some smaller updates and clarifications
 