### PR TITLE
add ncdiag to the stack

### DIFF
--- a/build_stack.sh
+++ b/build_stack.sh
@@ -207,6 +207,7 @@ build_lib wgrib2
 build_lib prod_util
 build_lib grib_util
 build_lib ncio
+build_lib ncdiag
 
 if $MODULES; then
 

--- a/docs/source/hpc-components.rst
+++ b/docs/source/hpc-components.rst
@@ -5,7 +5,7 @@
 HPC-Stack Components
 =====================
 
-The HPC-Stack packages are built in :numref:`Step %s <NonConHPCBuild>` using the ``build_stack.sh`` script. The following software can optionally be built with the scripts under ``libs``. 
+The HPC-Stack packages are built in :numref:`Step %s <NonConHPCBuild>` using the ``build_stack.sh`` script. The following software can optionally be built with the scripts under ``libs``.
 
 * **Compilers and MPI libraries**
 
@@ -78,6 +78,7 @@ The HPC-Stack packages are built in :numref:`Step %s <NonConHPCBuild>` using the
   * `NCEPLIBS-wrf_io <https://github.com/noaa-emc/nceplibs-wrf_io.git>`__
   * `EMC_crtm <https://github.com/noaa-emc/EMC_crtm.git>`__
   * `UPP <https://github.com/NOAA-EMC/UPP>`__
+  * `GSI-ncdiag <https://github.com/noaa-emc/GSI-ncdiag.git>`__
 
 
 * **JEDI Dependencies**

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -30,7 +30,7 @@ if $MODULES; then
 
   case $name in
     # The following require MPI
-    nemsiogfs | ncio )
+    nemsiogfs | ncio | ncdiag)
       module load hpc-$HPC_MPI
       using_mpi=YES
       ;;
@@ -43,7 +43,7 @@ if $MODULES; then
       if [[ "$major_ver" -le "2" ]]; then
           if [[ "$minor_ver" -le "5" ]]; then
               if [[ "$patch_ver" -lt "3" ]]; then
-                  [[ ! -z $mpi ]] || exit 0 
+                  [[ ! -z $mpi ]] || exit 0
                   module load hpc-$HPC_MPI
                   using_mpi=YES
                   w3dep="w3nco"
@@ -143,7 +143,7 @@ if $MODULES; then
     prod_util)
       module load w3nco
       ;;
-    ncio)
+    ncio | ncdiag)
       module load netcdf
       ;;
     bufr)
@@ -180,7 +180,7 @@ else
   eval prefix="\${${nameUpper}_ROOT:-'/usr/local'}"
   case $name in
     # The following require MPI
-    nemsio | nemsiogfs | ncio )
+    nemsio | nemsiogfs | ncio | ncdiag )
       using_mpi=YES
       ;;
     # The following can use MPI (if available)
@@ -237,6 +237,9 @@ case $name in
     else
       extraCMakeFlags="-DENABLE_MPI=OFF"
     fi
+    ;;
+  ncdiag)
+    URL="https://github.com/NOAA-EMC/GSI-ncdiag"
     ;;
 esac
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/ncdiag/ncdiag.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/ncdiag/ncdiag.lua
@@ -1,0 +1,29 @@
+help([[
+]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+depends_on("netcdf")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+setenv("ncdiag_ROOT", base)
+setenv("ncdiag_VERSION", pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: GSI NetCDF Diagnostics Library")

--- a/stack/stack_comgsi.yaml
+++ b/stack/stack_comgsi.yaml
@@ -205,3 +205,9 @@ ncio:
   version: develop
   install_as: 1.0.0
   is_nceplib: YES
+
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -235,6 +235,12 @@ ncio:
   install_as: 1.1.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -231,6 +231,12 @@ ncio:
   install_as: 1.1.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_jedi.yaml
+++ b/stack/stack_jedi.yaml
@@ -232,6 +232,12 @@ ncio:
   install_as: 1.0.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_mac.yaml
+++ b/stack/stack_mac.yaml
@@ -235,6 +235,12 @@ ncio:
   install_as: 1.1.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_mac_gnu.yaml
+++ b/stack/stack_mac_gnu.yaml
@@ -235,6 +235,12 @@ ncio:
   install_as: 1.0.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_mac_m1_gnu.yaml
+++ b/stack/stack_mac_m1_gnu.yaml
@@ -235,6 +235,12 @@ ncio:
   install_as: 1.0.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0

--- a/stack/stack_noaa.yaml
+++ b/stack/stack_noaa.yaml
@@ -231,6 +231,12 @@ ncio:
   install_as: 1.1.0
   is_nceplib: YES
 
+ncdiag:
+  build: YES
+  version: v1.0.0
+  install_as: 1.0.0
+  is_nceplib: YES
+
 boost:
   build: YES
   version: 1.68.0


### PR DESCRIPTION
Closes #467 
Adding the capability to build and deploy [GSI-ncdiag](https://github.com/noaa-emc/GSI-ncdiag) via the hpc-stack.