### PR TITLE
wgrib2 consitency and consolidation

### DIFF
--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -72,7 +72,7 @@ if $MODULES; then
       fi
       ;;
     # The following can use MPI (if available)
-    wrf_io | wgrib2)
+    wrf_io )
       if [[ ! -z $mpi ]]; then
         module load hpc-$HPC_MPI
         using_mpi=YES
@@ -84,15 +84,6 @@ if $MODULES; then
   case $name in
     wrf_io)
       module load netcdf
-      ;;
-    wgrib2)
-      module try-load jpeg
-      module try-load jasper
-      module try-load zlib
-      module try-load libpng
-      module load netcdf
-      module load sp
-      module load ip2
       ;;
     crtm)
       module load hpc-$HPC_MPI
@@ -184,7 +175,7 @@ else
       using_mpi=YES
       ;;
     # The following can use MPI (if available)
-    wrf_io | wgrib2)
+    wrf_io )
       [[ ! -z $mpi ]] && using_mpi=YES
       ;;
   esac
@@ -217,9 +208,6 @@ extraCMakeFlags=""
 case $name in
   crtm)
     URL="https://github.com/NOAA-EMC/crtm.git"
-    ;;
-  wgrib2)
-    extraCMakeFlags="${STACK_wgrib2_cmake_opts:-}"
     ;;
   bufr)
     if [[ ${using_python:-} =~ [yYtT] ]]; then

--- a/modulefiles/compiler/compilerName/compilerVersion/wgrib2/wgrib2.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/wgrib2/wgrib2.lua
@@ -11,16 +11,19 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
+load("netcdf")
+prereq("netcdf")
+
 local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 
-prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("PATH", pathJoin(base, "bin"))
 setenv("wgrib2_ROOT", base)
 setenv("wgrib2_VERSION", pkgVersion)
-setenv("WGRIB2_INC", pathJoin(base,"include"))
-setenv("WGRIB2_LIB", pathJoin(base,"lib","libwgrib2.a"))
-setenv("WGRIB2", pathJoin(base,"bin", "wgrib2"))
+setenv("WGRIB2_INC", pathJoin(base, "include"))
+setenv("WGRIB_LIB", pathJoin(base, "lib", "libwgrib2.a"))
+setenv("WGRIB2", pathJoin(base, "bin", "wgrib2"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/wgrib2/wgrib2.lua
@@ -20,12 +20,12 @@ local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 
-prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("PATH", pathJoin(base, "bin"))
 setenv("wgrib2_ROOT", base)
 setenv("wgrib2_VERSION", pkgVersion)
-setenv("WGRIB2_INC", pathJoin(base,"include"))
-setenv("WGRIB_LIB", pathJoin(base,"lib/libwgrib2.a"))
-setenv("WGRIB2_LIBAPI", pathJoin(base,"lib/libwgrib2_api.a"))
+setenv("WGRIB2_INC", pathJoin(base, "include"))
+setenv("WGRIB_LIB", pathJoin(base, "lib", "libwgrib2.a"))
+setenv("WGRIB2", pathJoin(base, "bin", "wgrib2"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)


### PR DESCRIPTION
Presently, hpc-stack provides two ways to build and install `wgrib2`.
- NCEPLibs-wgrib2.
- Native wgrib2 build from its developer.

This leads to inconsistencies in the artifacts (specifically library) that is used in downstream applications.

This PR:
- removes the ability to build NCEPLibs-wgrib2 and rely solely on the build mechanism provided by its developer.  
- Makes consistent modulefiles for wgrib2 between hierarchies. 
- Upgrades `wgrib2-config.cmake` that makes it easy for packages to "find" wgrib2.