### PR TITLE
NCO compliance for third-party software on FISMA High Systems

### DIFF
--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -3,8 +3,8 @@
 set -eux
 
 name="atlas"
-repo=${1:-${STACK_atlas_repo:-"jcsda"}}
-version=${2:-${STACK_atlas_version:-"release-stable"}}
+repo=${1:-${STACK_atlas_repo:-"ecmwf"}}
+version=${2:-${STACK_atlas_version:-"master"}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')

--- a/libs/build_atlas.sh
+++ b/libs/build_atlas.sh
@@ -51,6 +51,17 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 git checkout $version
+
+# Conform to NCO IT FISMA High Standards
+if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
+  sed -i 's|http://www.ecmwf.int||g' cmake/atlas-import.cmake.in
+  sed -i 's|int.emcwf||g' cmake/atlas-import.cmake.in
+  sed -r -i 's|http[]://[a-zA-Z0-9@${}_./]*||g' cmake/atlas_export.cmake
+  rm -f .travis.yml
+  rm -f tools/install*.sh
+  rm -f tools/github-sha.sh
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/libs/build_ecbuild.sh
+++ b/libs/build_ecbuild.sh
@@ -3,8 +3,8 @@
 set -eux
 
 name="ecbuild"
-repo=${1:-${STACK_ecbuild_repo:-"jcsda"}}
-version=${2:-${STACK_ecbuild_version:-"release-stable"}}
+repo=${1:-${STACK_ecbuild_repo:-"ecmwf"}}
+version=${2:-${STACK_ecbuild_version:-"master"}}
 
 if $MODULES; then
   set +x
@@ -18,7 +18,7 @@ if $MODULES; then
       if [[ $OVERWRITE =~ [yYtT] ]]; then
           echo "WARNING: $prefix EXISTS: OVERWRITING!"
           $SUDO rm -rf $prefix
-          $SUDO mkdir $prefix 
+          $SUDO mkdir $prefix
       else
           echo "WARNING: $prefix EXISTS, SKIPPING"
           exit 0
@@ -35,11 +35,20 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 git checkout $version
+
+# Conform to NCO IT FISMA High Standards
+if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
+  sed -r -i 's|ssh://[a-zA-Z0-9.@]*||g' cmake/compat/ecmwf_git.cmake
+  sed -r -i 's|http[]://[a-zA-Z0-9@${}_./]*||g' cmake/compat/ecmwf_git.cmake
+  sed -r -i 's|http[]://[a-zA-Z0-9./-]*/test-data|DISABLED_BY_DEFAULT|g' cmake/ecbuild_check_urls.cmake
+  sed -r -i 's|http[]://[a-zA-Z0-9./-]*/test-data|DISABLED_BY_DEFAULT|g' cmake/ecbuild_get_test_data.cmake
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
+../bin/ecbuild --prefix=$prefix ..
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 VERBOSE=$MAKE_VERBOSE $SUDO make install
 

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -3,8 +3,8 @@
 set -eux
 
 name="eckit"
-repo=${1:-${STACK_eckit_repo:-"jcsda"}}
-version=${2:-${STACK_eckit_version:-"release-stable"}}
+repo=${1:-${STACK_eckit_repo:-"ecmwf"}}
+version=${2:-${STACK_eckit_version:-"master"}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')

--- a/libs/build_eckit.sh
+++ b/libs/build_eckit.sh
@@ -50,6 +50,12 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 git checkout $version
+
+# Conform to NCO IT FISMA High Standards
+if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
+  rm -f .travis.yml
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 sed -i -e 's/project( eckit CXX/project( eckit CXX Fortran/' CMakeLists.txt
 [[ -d build ]] && $SUDO rm -rf build

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -50,6 +50,14 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 git checkout $version
+
+# Conform to NCO IT FISMA High Standards
+if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
+	rm -f tools/install-*
+	rm -f tools/github-sha*
+	rm -f .travis.yml
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/libs/build_fckit.sh
+++ b/libs/build_fckit.sh
@@ -3,8 +3,8 @@
 set -eux
 
 name="fckit"
-repo=${1:-${STACK_fckit_repo:-"jcsda"}}
-version=${2:-${STACK_fckit_version:-"release-stable"}}
+repo=${1:-${STACK_fckit_repo:-"ecmwf"}}
+version=${2:-${STACK_fckit_version:-"master"}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
@@ -53,9 +53,9 @@ git checkout $version
 
 # Conform to NCO IT FISMA High Standards
 if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
-	rm -f tools/install-*
-	rm -f tools/github-sha*
-	rm -f .travis.yml
+  rm -f tools/install-*
+  rm -f tools/github-sha*
+  rm -f .travis.yml
 fi
 
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0

--- a/libs/build_yafyaml.sh
+++ b/libs/build_yafyaml.sh
@@ -41,6 +41,12 @@ URL="https://github.com/$repo/$name.git"
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
 git checkout $version
+
+# Conform to NCO IT FISMA High Standards
+if [[ ${NCO_IT_CONFORMING:-"NO"} =~ [yYtT] ]]; then
+  rm -f tools/ci-install-gfe.bash
+fi
+
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
 [[ -d build ]] && $SUDO rm -rf build


### PR DESCRIPTION
During the review of software requests for installation on NOAA's operational HPC WCOSS2, NCO IT team flagged several software as non-compliant and were rejected.

This PR:
- addresses the NCO IT security team reviews and concerns.
- addresses the concerns for `ecbuild`, `eckit`, `fckit`, `atlas` and `yafyaml`.
- repoints EMCWF softwares to ECMWF authoritative repositories as default rather than JCSDA.

The IT security manual is available within the NOAA domain.  