### PR TITLE
update checkout version and clean after success

### DIFF
--- a/.github/workflows/build_intel.yaml
+++ b/.github/workflows/build_intel.yaml
@@ -47,7 +47,7 @@ jobs:
         sudo python3 -m pip install -U netCDF4
 
     - name: Get sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: hpc-stack
 
@@ -62,10 +62,16 @@ jobs:
         export HPC_PYTHON="python/${python_ver}"
         yes | ./setup_modules.sh -c config/config_custom.sh -p $prefix
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_custom.yaml -m
-        
+
     - name: Upload logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
         name: intel-log
         path: intel/log
+
+    - name: Clean disk space of downloaded packages
+      if: ${{ success() }}
+      run: |
+        cd hpc-stack
+        rm -rf pkg

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -29,7 +29,7 @@ jobs:
         sudo ln -s /usr/local/Cellar/openssl@1.1/$ssl_ver/lib/libcrypto.1.1.dylib /usr/local/lib/libcrypto.dylib
 
     - name: Get sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ${{ matrix.compiler }}-${{ matrix.mpi }}
 
@@ -62,3 +62,9 @@ jobs:
       with:
         name: ${{ matrix.compiler }}-${{ matrix.mpi }}-log
         path: ${{ matrix.compiler }}-${{ matrix.mpi }}/log
+
+    - name: Clean disk space of downloaded packages
+      if: ${{ success() }}
+      run: |
+        cd ${{ matrix.compiler }}-${{ matrix.mpi }}
+        rm -rf pkg

--- a/.github/workflows/build_ubuntu.yaml
+++ b/.github/workflows/build_ubuntu.yaml
@@ -51,7 +51,7 @@ jobs:
         sudo python3 -m pip install -U netCDF4
 
     - name: Get sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ${{ matrix.mpi }}
 
@@ -77,3 +77,9 @@ jobs:
       with:
         name: ${{ matrix.mpi }}-log
         path: ${{ matrix.mpi }}/log
+
+    - name: Clean disk space of downloaded packages
+      if: ${{ success() }}
+      run: |
+        cd ${{ matrix.mpi }}
+        rm -rf pkg

--- a/.github/workflows/test_download_only.yaml
+++ b/.github/workflows/test_download_only.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Get sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: hpc-stack
 
@@ -23,3 +23,9 @@ jobs:
         prefix=$GITHUB_WORKSPACE/install
         sed -i "s/install_fix: YES/install_fix: NO/" stack/stack_noaa.yaml
         ./build_stack.sh -p $prefix -c config/config_custom.sh -y stack/stack_noaa.yaml
+
+    - name: Clean disk space of downloaded packages
+      if: ${{ success() }}
+      run: |
+        cd hpc-stack
+        rm -rf pkg


### PR DESCRIPTION
This PR:
- updates the checkout action to v3 to remove annoying Github Actions warnings
- cleans out the `pkg/` directory after a successful action.  This should not be necessary as the scratch space is cleaned out automatically, but it does no harm.