### PR TITLE
Update develop branch: new versions, packages, package locations, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ S4          | David Huber
 
 ## Contributors
 
-Mark Potts, Steve Lawrence, Ed Hartnett, Guoqing Ge, Raffaele Montuoro, David Huber
+Mark Potts, Steve Lawrence, Ed Hartnett, Guoqing Ge, Raffaele Montuoro, David Huber, Natalie Perlin
 
 ## Prerequisites:
 

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -262,6 +262,7 @@ build_lib metplus
 # UFS 3rd party dependencies
 
 build_lib esmf
+build_lib scotch
 build_lib fms
 build_lib cmakemodules
 build_lib esma_cmake

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -145,6 +145,7 @@ build_lib sqlite
 build_lib libtiff
 build_lib proj
 build_lib geos
+build_lib openblas
 
 # Also build serial versions of HDF5 and netCDF, if using MODULES
 if $MODULES; then

--- a/config/config_macos_gnu.sh
+++ b/config/config_macos_gnu.sh
@@ -5,9 +5,9 @@ LMOD=$(brew --prefix lmod)
 source $LMOD/init/profile
 
 # Compiler/MPI combination
-export HPC_COMPILER="gnu/11.3.0"
-export HPC_MPI="openmpi/4.1.2"
-export HPC_PYTHON="python/3.9.13"
+export HPC_COMPILER="gnu/12.3.0"
+export HPC_MPI="openmpi/4.1.5"
+export HPC_PYTHON="python/3.11.6"
 
 # Build options
 export USE_SUDO=N

--- a/config/config_macos_gnu.sh
+++ b/config/config_macos_gnu.sh
@@ -14,7 +14,7 @@ export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=log
 export OVERWRITE=N
-export NTHREADS=8
+export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=Y
 export   MAKE_CLEAN=N
@@ -24,8 +24,12 @@ export WGET="wget -nv "
 
 #
 # gfortran-10 needs the following
-export STACK_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz"
+export STACK_FFLAGS="-fallow-argument-mismatch -fallow-invalid-boz -march=native "
+export STACK_CFLAGS="-march=native"
 export STACK_CXXFLAGS="-march=native"
+export STACK_mpi_FFLAGS="-fopenmp"
+export STACK_mpi_CFLAGS="-fopenmp"
+export STACK_mpi_CXXFLAGS="-fopenmp"
 
 BREW=$(brew --prefix)
 

--- a/libs/build_esmf.sh
+++ b/libs/build_esmf.sh
@@ -13,7 +13,9 @@ compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 COMPILER=$(echo $HPC_COMPILER | cut -d/ -f1)
+[[ "$COMPILER" = *"intel"* ]] && COMPILER="intel"
 MPI=$(echo $HPC_MPI | cut -d/ -f1)
+[[ "$MPI" = *"oneapi-mpi"* ]] && MPI="impi"
 
 host=$(uname -s)
 abi64=$(uname -m)

--- a/libs/build_met.sh
+++ b/libs/build_met.sh
@@ -4,6 +4,7 @@ set -eux
 
 name="met"
 version=${1:-${STACK_met_version}}
+release_date=${2:-${STACK_met_release_date}}
 install_as=${STACK_met_install_as:-${version}}
 
 # Hyphenated version used for install prefix
@@ -15,7 +16,7 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_PYTHON
+    [[ ${STACK_met_enable_python:-} =~ [yYtT] ]] && module load hpc-$HPC_PYTHON
     module load gsl
     module load bufr
     module load zlib
@@ -46,8 +47,10 @@ fi
 
 cd  ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 software=MET-$version
-URL="https://github.com/dtcenter/MET/archive/refs/tags/v$version.tar.gz"
-[[ -d $software ]] || ( $WGET $URL; tar -xf v$version.tar.gz )
+software=$name-$version.$release_date
+pkg_name=$name-$version
+URL="https://github.com/dtcenter/MET/releases/download/v$version/$software.tar.gz"
+[[ -d $pkg_name ]] || ( $WGET $URL; tar -xf $software.tar.gz )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
 export MET_BASE=$prefix/share/met
@@ -103,9 +106,9 @@ LDFLAGS4="-L${LIB_JASPER} -L${MET_HDF5}/lib -L${LIB_LIBPNG} -L${LIB_Z}"
 export LDFLAGS="-fPIE ${LDFLAGS2:-} ${LDFLAGS3:-} ${LDFLAGS4:-}"
 export LIBS="-lhdf5_hl -lhdf5 -lz -ldl"
 
-[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+[[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
 
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${software}
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${pkg_name}
 curr_dir=$(pwd)
 
 extra_flags="--enable-grib2 "

--- a/libs/build_met.sh
+++ b/libs/build_met.sh
@@ -4,7 +4,6 @@ set -eux
 
 name="met"
 version=${1:-${STACK_met_version}}
-release_date=${2:-${STACK_met_release_date}}
 install_as=${STACK_met_install_as:-${version}}
 
 # Hyphenated version used for install prefix
@@ -46,10 +45,9 @@ fi
 
 
 cd  ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
-software=$name-$version.$release_date
-pkg_name=$name-$version
-URL="https://github.com/dtcenter/MET/releases/download/v$version/$software.tar.gz"
-[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.gz )
+software=MET-$version
+URL="https://github.com/dtcenter/MET/archive/refs/tags/v$version.tar.gz"
+[[ -d $software ]] || ( $WGET $URL; tar -xf v$version.tar.gz )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
 export MET_BASE=$prefix/share/met
@@ -105,9 +103,9 @@ LDFLAGS4="-L${LIB_JASPER} -L${MET_HDF5}/lib -L${LIB_LIBPNG} -L${LIB_Z}"
 export LDFLAGS="-fPIE ${LDFLAGS2:-} ${LDFLAGS3:-} ${LDFLAGS4:-}"
 export LIBS="-lhdf5_hl -lhdf5 -lz -ldl"
 
-[[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${pkg_name}
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${software}
 curr_dir=$(pwd)
 
 extra_flags="--enable-grib2 "

--- a/libs/build_met.sh_11.0.2
+++ b/libs/build_met.sh_11.0.2
@@ -1,0 +1,121 @@
+#!/bin/bash    
+
+set -eux
+
+name="met"
+version=${1:-${STACK_met_version}}
+install_as=${STACK_met_install_as:-${version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+
+[[ ${STACK_met_enable_python:-} =~ [yYtT] ]] && enable_python=YES || enable_python=NO
+
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module load hpc-$HPC_COMPILER
+    module load hpc-$HPC_PYTHON
+    module load gsl
+    module load bufr
+    module load zlib
+    module load jasper
+    module try-load libpng
+    module load g2c
+    module load hdf5
+    module load netcdf
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+    if [[ -d $prefix ]]; then
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
+    fi
+else
+
+    prefix=${MET_ROOT:-"/usr/local"}
+
+fi
+
+
+cd  ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+software=MET-$version
+URL="https://github.com/dtcenter/MET/archive/refs/tags/v$version.tar.gz"
+[[ -d $software ]] || ( $WGET $URL; tar -xf v$version.tar.gz )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+export MET_BASE=$prefix/share/met
+
+export FC=$SERIAL_FC
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+
+export F77=$FC
+export FFLAGS="${STACK_FFLAGS:-} ${STACK_met_FFLAGS:-}"
+export CFLAGS="${STACK_CFLAGS:-} ${STACK_met_CFLAGS:-}"
+
+export CFLAGS+="-D__64BIT__"
+export CXXFLAGS+="-D__64BIT__"
+
+export MET_NETCDF=${NETCDF_ROOT}
+export MET_HDF5=${HDF5_ROOT}
+
+bufr_libdir=`find ${bufr_ROOT:-${BUFR_ROOT}} -name libbufr_4.a -exec dirname {} \;`
+export MET_BUFRLIB=$bufr_libdir
+g2c_libdir=`find ${g2c_ROOT:-${G2C_ROOT}} -name libg2c.a -exec dirname {} \;`
+export MET_GRIB2CLIB=$g2c_libdir
+export MET_GRIB2CINC=${G2C_ROOT:-${g2c_ROOT}}/include
+export MET_GSL=${GSL_ROOT}
+export BUFRLIB_NAME=-lbufr_4
+export GRIB2CLIB_NAME=-lg2c
+jasper_libdir=`find ${JASPER_ROOT} -name libjasper.a -exec dirname {} \;`
+export LIB_JASPER=$jasper_libdir
+
+export LIB_LIBPNG=${PNG_LIBRARIES}
+export LIB_Z=${ZLIB_ROOT}/lib
+
+if [[ $enable_python =~ [yYtT] ]]; then
+    export MET_PYTHON=${MET_PYTHON:-`which python3`}
+
+    if [[ -z ${MET_PYTHON_CC+x} ]]; then
+        #export MET_PYTHON_CC=`$MET_PYTHON_CONFIG --cflags`
+        echo "Set MET_PYTHON_CC to include 'Python.h' usually found through 'python3-config --cflfags'"
+        exit 1
+    fi
+
+    if [[ -z ${MET_PYTHON_LD+x} ]]; then
+        #export MET_PYTHON_LD=`$MET_PYTHON_CONFIG --ldflags`
+        echo "Set MET_PYTHON_LD to to link to libpython found through 'python3-config --ldflags"
+        exit 1
+    fi
+fi
+
+LDFLAGS2="-L${MET_NETCDF}/lib -L${MET_HDF5}/lib -L${MET_BUFRLIB}"
+LDFLAGS3="-L${MET_GRIB2CLIB} -L${MET_GSL}/lib"
+LDFLAGS4="-L${LIB_JASPER} -L${MET_HDF5}/lib -L${LIB_LIBPNG} -L${LIB_Z}"
+
+export LDFLAGS="-fPIE ${LDFLAGS2:-} ${LDFLAGS3:-} ${LDFLAGS4:-}"
+export LIBS="-lhdf5_hl -lhdf5 -lz -ldl"
+
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${software}
+curr_dir=$(pwd)
+
+extra_flags="--enable-grib2 "
+[[ $enable_python =~ [yYtT] ]] && extra_flags+="--enable-python "
+./configure --prefix=$prefix BUFRLIB_NAME=${BUFRLIB_NAME} GRIB2CLIB_NAME=${GRIB2CLIB_NAME} ${extra_flags:-}
+
+make
+[[ $MAKE_CHECK =~ [yYtT] ]] && make check
+$SUDO make install
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $install_as
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_met.sh_11.0.2
+++ b/libs/build_met.sh_11.0.2
@@ -15,7 +15,7 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load hpc-$HPC_COMPILER
-    module load hpc-$HPC_PYTHON
+    [[ ${STACK_met_enable_python:-} =~ [yYtT] ]] && module load hpc-$HPC_PYTHON
     module load gsl
     module load bufr
     module load zlib

--- a/libs/build_metplus.sh
+++ b/libs/build_metplus.sh
@@ -13,12 +13,14 @@ software="v"$version
 pkg_name=METplus-$version
 met_version=${1:-${STACK_met_version}}
 URL="https://github.com/dtcenter/METplus/archive/$software.tar.gz"
-[[ -d $pkg_name ]] || ( $WGET $URL; tar -xf $software.tar.gz )
+[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.gz )
 [[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
 
 if $MODULES; then
+  source $MODULESHOME/init/bash
+    module load hpc-$HPC_COMPILER
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version" 
-    met_prefix="${PREFIX:-"/opt/modules"}/$compiler"
+    met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler"}
 else
     prefix=${MET_ROOT:-"/usr/local"}
     met_prefix=$prefix
@@ -43,7 +45,7 @@ curr_dir=$(pwd)
 
 # Update the path to the MET tools for the users
 cd ${curr_dir}/parm/metplus_config
-cat metplus_system.conf | \
+cat defaults.conf | \
   sed "s%MET_INSTALL_DIR = /path/to%MET_INSTALL_DIR = $met_prefix/met/$met_version%g" \
   > metplus_system_new.conf
 mv metplus_system_new.conf metplus_system.conf

--- a/libs/build_metplus.sh
+++ b/libs/build_metplus.sh
@@ -17,8 +17,10 @@ URL="https://github.com/dtcenter/METplus/archive/$software.tar.gz"
 [[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
 
 if $MODULES; then
-  source $MODULESHOME/init/bash
+    source $MODULESHOME/init/bash
     module load hpc-$HPC_COMPILER
+    module try-load met
+    echo "Using module met version (none if blank) = ${MET_VERSION:-:}"
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version" 
     met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler"}
 else

--- a/libs/build_metplus.sh
+++ b/libs/build_metplus.sh
@@ -13,7 +13,7 @@ software="v"$version
 pkg_name=METplus-$version
 met_version=${1:-${STACK_met_version}}
 URL="https://github.com/dtcenter/METplus/archive/$software.tar.gz"
-[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.gz )
+[[ -d $pkg_name ]] || ( $WGET $URL; tar -xf $software.tar.gz )
 [[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
 
 if $MODULES; then

--- a/libs/build_metplus.sh
+++ b/libs/build_metplus.sh
@@ -7,22 +7,30 @@ version=${1:-${STACK_metplus_version}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
 cd  ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 software="v"$version
 pkg_name=METplus-$version
 met_version=${1:-${STACK_met_version}}
 URL="https://github.com/dtcenter/METplus/archive/$software.tar.gz"
-[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.gz )
+[[ -d $software || -f $software.tar.gz ]]  || ( $WGET $URL )
+[[ -d $software ]] ||  tar -xf $software.tar.gz 
 [[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
 
 if $MODULES; then
     source $MODULESHOME/init/bash
     module load hpc-$HPC_COMPILER
+    [[ ! -z $mpi ]] && module load hpc-$HPC_MPI
     module try-load met
     echo "Using module met version (none if blank) = ${MET_VERSION:-:}"
-    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version" 
-    met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler"}
+    if [[ -z $mpi ]]; then
+      prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version" 
+      met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler"}
+    else
+      prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+      met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler/$mpi"}
+    fi
 else
     prefix=${MET_ROOT:-"/usr/local"}
     met_prefix=$prefix
@@ -52,7 +60,7 @@ cat defaults.conf | \
   > metplus_system_new.conf
 mv metplus_system_new.conf metplus_system.conf
 
-
 # generate modulefile from template
-$MODULES && update_modules compiler $name $version
+[[ -z $mpi ]] && modpath=compiler || modpath=mpi
+$MODULES && update_modules $modpath $name $version
 echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_metplus.sh_5.0.2
+++ b/libs/build_metplus.sh_5.0.2
@@ -1,0 +1,58 @@
+#!/bin/bash                                                                                                                              
+
+set -eux
+
+name="metplus"
+version=${1:-${STACK_metplus_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+
+cd  ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+software="v"$version
+pkg_name=METplus-$version
+met_version=${1:-${STACK_met_version}}
+URL="https://github.com/dtcenter/METplus/archive/$software.tar.gz"
+[[ -d $software ]] || ( $WGET $URL; tar -xf $software.tar.gz )
+[[ -d $pkg_name ]] && cd $pkg_name || ( echo "$pkg_name does not exist, ABORT!"; exit 1 )
+
+if $MODULES; then
+  source $MODULESHOME/init/bash
+    module load hpc-$HPC_COMPILER
+    module try-load met
+    echo "Using module met version (none if blank) = ${MET_VERSION:-:}"
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version" 
+    met_prefix=${MET_ROOT:-"${PREFIX:-"/opt/modules"}/$compiler"}
+else
+    prefix=${MET_ROOT:-"/usr/local"}
+    met_prefix=$prefix
+fi
+
+if [[ -d $prefix ]]; then
+    if [[ $OVERWRITE =~ [yYtT] ]]; then
+        echo "WARNING: $prefix EXISTS: OVERWRITING!"
+        $SUDO rm -rf $prefix
+    else
+        echo "WARNING: $prefix EXISTS, SKIPPING"
+        exit 0
+    fi
+fi
+
+mkdir -p $prefix
+
+# Install is simply copying over the unpacked package to the install location
+cp -r ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/${pkg_name}/* $prefix
+cd $prefix
+curr_dir=$(pwd)
+
+# Update the path to the MET tools for the users
+cd ${curr_dir}/parm/metplus_config
+cat defaults.conf | \
+  sed "s%MET_INSTALL_DIR = /path/to%MET_INSTALL_DIR = $met_prefix/met/$met_version%g" \
+  > metplus_system_new.conf
+mv metplus_system_new.conf metplus_system.conf
+
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $version
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -303,7 +303,7 @@ if [[ ${name} == "prod_util"  &&  "$(printf '%s\n' "$min_version" "$install_as" 
      cd ..
    done
    if [ $? -eq 0 ]; then
-      cp -r ../ush/* ../build/bin/.
+      chmod 755 ../ush/* && cp -r ../ush/* ../build/bin/.
       [[ ! -d $prefix ]] && mkdir $prefix
       mv ../build/bin $prefix/.
    fi

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -82,10 +82,7 @@ if $MODULES; then
 
   # Load dependencies
   case $name in
-    wrf_io)
-      module load netcdf
-      ;;
-    crtm)
+    wrf_io | crtm)
       module load netcdf
       ;;
     ip | ip2)

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -157,7 +157,7 @@ if $MODULES; then
       if [[ $OVERWRITE =~ [yYtT] ]]; then
           echo "WARNING: $prefix EXISTS: OVERWRITING!"
           $SUDO rm -rf $prefix
-          $SUDO mkdir $prefix
+          $SUDO mkdir -p $prefix
       else
           echo "WARNING: $prefix EXISTS, SKIPPING"
           exit 0
@@ -304,7 +304,7 @@ if [[ ${name} == "prod_util"  &&  "$(printf '%s\n' "$min_version" "$install_as" 
    done
    if [ $? -eq 0 ]; then
       chmod 755 ../ush/* && cp -r ../ush/* ../build/bin/.
-      [[ ! -d $prefix ]] && mkdir $prefix
+      [[ ! -d $prefix ]] && mkdir -p $prefix
       mv ../build/bin $prefix/.
    fi
    [[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH" 

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -327,7 +327,7 @@ if [[ "$name" == "crtm" ]]; then
       mkdir -p $prefix/fix
       find ./crtm_fix-${install_as} -type f \( -path '*/Big_Endian/*' -o -path '*/netcdf/*' -o -path '*/netCDF/*' \) -not -path '*/Little_Endian/*' -exec cp -p {} $prefix/fix \;
       mv $prefix/fix/amsua_metop-c.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.noACC.bin
-      cp -p ./crtm_fix-${install_as}/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
+      cp -p ./crtm_fix-${install_as}/fix/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
     fi
   fi
 fi

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -325,20 +325,9 @@ if [[ "$name" == "crtm" ]]; then
   if [[ ${STACK_crtm_install_fix:-} =~ [yYtT] ]]; then
     if [[ -d crtm_fix-${install_as} ]]; then
       mkdir -p $prefix/fix
-      cp -p ./crtm_fix-${install_as}/AerosolCoeff/Big_Endian/* $prefix/fix
-      cp -p ./crtm_fix-${install_as}/CloudCoeff/Big_Endian/* $prefix/fix
-      cp -p ./crtm_fix-${install_as}/EmisCoeff/*/Big_Endian/* $prefix/fix
-      cp -p ./crtm_fix-${install_as}/EmisCoeff/*/*/Big_Endian/* $prefix/fix
-      cp -p ./crtm_fix-${install_as}/SpcCoeff/Big_Endian/* $prefix/fix
-      cp -p ./crtm_fix-${install_as}/TauCoeff/ODPS/Big_Endian/* $prefix/fix
-      if [[ "${install_as}" == "2.4.0" ]]; then
-         cp -p ./crtm_fix-${install_as}/ACCoeff/netcdf/* $prefix/fix
-         cp -p ./crtm_fix-${install_as}/AerosolCoeff/netCDF/* $prefix/fix
-         cp -p ./crtm_fix-${install_as}/CloudCoeff/netCDF/* $prefix/fix
-         cp -p ./crtm_fix-${install_as}/SpcCoeff/netcdf/* $prefix/fix
-         mv $prefix/fix/amsua_metop-c.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.noACC.bin
-         cp -p ./crtm_fix-${install_as}/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
-      fi
+      find ./crtm_fix-${install_as} -type f \( -path '*/Big_Endian/*' -o -path '*/netcdf/*' -o -path '*/netCDF/*' \) -not -path '*/Little_Endian/*' -exec cp -p {} $prefix/fix \;
+      mv $prefix/fix/amsua_metop-c.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.noACC.bin
+      cp -p ./crtm_fix-${install_as}/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
     fi
   fi
 fi

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -327,7 +327,7 @@ if [[ "$name" == "crtm" ]]; then
       mkdir -p $prefix/fix
       find ./crtm_fix-${install_as} -type f \( -path '*/Big_Endian/*' -o -path '*/netcdf/*' -o -path '*/netCDF/*' \) -not -path '*/Little_Endian/*' -exec cp -p {} $prefix/fix \;
       mv $prefix/fix/amsua_metop-c.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.noACC.bin
-      cp -p ./crtm_fix-${install_as}/fix/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
+      cp -p ./crtm_fix-${install_as}/SpcCoeff/Little_Endian/amsua_metop-c_v2.SpcCoeff.bin $prefix/fix/amsua_metop-c.SpcCoeff.bin
     fi
   fi
 fi

--- a/libs/build_nceplibs.sh
+++ b/libs/build_nceplibs.sh
@@ -82,7 +82,10 @@ if $MODULES; then
 
   # Load dependencies
   case $name in
-    wrf_io | crtm)
+    wrf_io)
+      module load netcdf
+      ;;
+    crtm)
       module load netcdf
       ;;
     ip | ip2)
@@ -225,20 +228,39 @@ case $name in
   ncdiag)
     URL="https://github.com/NOAA-EMC/GSI-ncdiag"
     ;;
+  prod_util)
+    min_version="2.0.13"
+    min_version2="2.0.14"
+    if [ "$(printf '%s\n' "$min_version" "$install_as" | sort -V | head -n1)" = "$min_version" ]; then 
+       # echo "min_version is $min_version";
+       URL="git@github.com:NCEP-NCO/prod_util.git"
+    fi
+    if [ "$(printf '%s\n' "$min_version2" "$install_as" | sort -V | head -n1)" = "$min_version2" ]; then 
+       URL="https://www.nco.ncep.noaa.gov/pmb/codes/nwprod/prod_util.${version}/"
+    fi
+    ;;
 esac
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 software=$name-$version
-if [[ ! -d $software ]]; then
-  export GIT_LFS_SKIP_SMUDGE=1
-  git clone $URL $software
-  cd $software
-  if [[ "$name" == "crtm" ]]; then
-    version=release/REL-${install_as}_emc
-  fi
-  git checkout $version
-  git submodule update --init --recursive
+if [[ ${name} == "prod_util"  &&  "$(printf '%s\n' "$min_version2" "$install_as" | sort -V | head -n1)" = "$min_version2" ]] ; then
+   if [[ ! -d $software ]]; then
+     mkdir $software
+     cd $software
+     wget --recursive --convert-links --quiet --no-parent -nH --cut-dirs=4 -E -R html $URL
+   fi
+else
+   if [[ ! -d $software ]]; then
+     export GIT_LFS_SKIP_SMUDGE=1
+     git clone $URL $software
+     cd $software
+     if [[ "$name" == "crtm" ]]; then
+       version=release/REL-${install_as}_emc
+     fi
+     git checkout $version
+     git submodule update --init --recursive
+   fi
 fi
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
@@ -265,15 +287,37 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
-cmake .. \
+if [[ ${name} == "prod_util"  &&  "$(printf '%s\n' "$min_version" "$install_as" | sort -V | head -n1)" = "$min_version" ]] ; then
+   mkdir bin
+   cd ../sorc
+   for dir in fsync_file.cd  mdate.fd  ndate.fd  nhour.fd; do
+     cd $dir 
+     sed -i "s:ifort:${FC}:" makefile
+     sed -i "s:icc:${CC}:" makefile
+     exe=${dir/.*/}
+     rm -f $exe
+     make
+     if [ $? -eq 0 ]; then
+       mv $exe ../../build/bin/.
+     fi
+     cd ..
+   done
+   if [ $? -eq 0 ]; then
+      cp -r ../ush/* ../build/bin/.
+      [[ ! -d $prefix ]] && mkdir $prefix
+      mv ../build/bin $prefix/.
+   fi
+   [[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH" 
+else
+    cmake .. \
   -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_Fortran_COMPILER=${FC} \
   -DENABLE_TESTS=OFF -DOPENMP=${openmp} ${extraCMakeFlags:-}
 
-VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
-[[ $MAKE_CHECK =~ [yYtT] ]] && make check
-[[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
+  VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
+  [[ $MAKE_CHECK =~ [yYtT] ]] && make check
+  [[ $USE_SUDO =~ [yYtT] ]] && sudo -- bash -c "export PATH=$PATH; make install" \
                           || make install
-
+fi
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 # Install CRTM fix files

--- a/libs/build_openblas.sh
+++ b/libs/build_openblas.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -eux
+
+name="openblas"
+version=${1:-${STACK_openblas_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module is-loaded netcdf && module unload netcdf
+  module is-loaded intel &&  module unload intel
+  module load hpc-$HPC_COMPILER
+  module list
+  set -x
+
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+  if [[ -d $prefix ]]; then
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
+  fi
+else
+  prefix=${OPENBLAS_ROOT:-"/usr/local"}
+fi
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software="OpenBLAS-$version"
+URL="https://github.com/xianyi/OpenBLAS/releases/download/v$version/$software.tar.gz"
+[[ -f $software.tar.gz ]] || ( $WGET $URL )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+[[ -f $software.tar.gz ]] && tar -xvf $software.tar.gz || ( echo "$software tarfile does not exist, ABORT!"; exit 1 )
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+FC=${FC:-gfortran}
+
+make FC=$FC -j${NTHREADS:-4}
+
+make PREFIX=$prefix install
+
+# generate modulefile from template
+modpath=compiler
+$MODULES && update_modules $modpath $name $version
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -20,7 +20,11 @@ if $MODULES; then
   set -x
 
   install_as=${STACK_scotch_install_as:-${version}}
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
+  if [[ ! -z $mpi ]]; then
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
+  else
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$install_as"
+  fi
   if [[ -d $prefix ]]; then
       if [[ $OVERWRITE =~ [yYtT] ]]; then
           echo "WARNING: $prefix EXISTS: OVERWRITING!"

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -19,7 +19,7 @@ if $MODULES; then
   module list
   set -x
 
-  install_as=${STACK_scotch_install_as:-${version}}
+  install_as=${STACK_scotch_install_as:-${id}}
   if [[ ! -z $mpi ]]; then
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
   else

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -eux
+
+name="scotch"
+version=${1:-${STACK_scotch_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+mpi=$(echo $HPC_MPI | sed 's/\//-/g')
+id=$(echo $version | sed 's/v//')
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  [[ -z $mpi ]] || module load hpc-$HPC_MPI
+  module list
+  set -x
+
+  install_as=${STACK_scotch_install_as:-${version}}
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$install_as"
+  if [[ -d $prefix ]]; then
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
+  fi
+else
+  prefix=${SCOTCH_ROOT:-"/usr/local"}
+fi
+
+if [[ ! -z $mpi ]]; then
+  export FC=$MPI_FC
+  export CC=$MPI_CC
+  export CXX=$MPI_CXX
+else
+  export FC=$SERIAL_FC
+  export CC=$SERIAL_CC
+  export CXX=$SERIAL_CXX
+fi
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+URL="https://gitlab.inria.fr/scotch/scotch/-/archive/$version/scotch-$version.tar.gz"
+[[ -f $software.tar.gz ]] || ( $WGET $URL )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+[[ -f $software.tar.gz ]] && tar -xvf $software.tar.gz || ( echo "$software tarfile does not exist, ABORT!"; exit 1 )
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+
+# Compile & Install Scotch/PTscotch
+cmake VERBOSE=1 -DCMAKE_C_FLAGS="-std=gnu11" -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_C_COMPILER=${CC} -DMAKE_CXX_COMPILER=${CXX}   -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release -DTHREADS=OFF -DMPI_THREAD_MULTIPLE=OFF ..
+
+make VERBOSE=1
+make install
+
+# generate modulefile from template
+[[ -z $mpi ]] && modpath=compiler || modpath=mpi
+$MODULES && update_modules $modpath $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -78,7 +78,6 @@ sed -i'.backup' "s:^MAKE_FTN_API=.*:MAKE_FTN_API=${STACK_wgrib2_ftn_api:-1}:" ma
 sed -i'.backup' "s:^USE_G2CLIB=.*:USE_G2CLIB=${STACK_wgrib2_g2clib:-0}:" makefile
 sed -i'.backup' "s:^USE_PNG=.*:USE_PNG=${STACK_wgrib2_png:-1}:" makefile
 sed -i'.backup' "s:^USE_AEC=.*:USE_AEC=${STACK_wgrib2_aec:-1}:" makefile
-sed -i'.backup' "s:\\\#define :\#define :g" makefile
 
 # Fix openmp flag in older version of wgrib2. Intel compilers no longer accept -openmp.
 sed -i'.backup' "s:-openmp:-qopenmp:" makefile
@@ -112,7 +111,6 @@ if [[ ${STACK_wgrib2_lib:-n} =~ [yYtT] ]]; then
     sed -i'.backup' "s:^USE_G2CLIB=.*:USE_G2CLIB=0:" makefile
     sed -i'.backup' "s:^USE_PNG=.*:USE_PNG=0:" makefile
     sed -i'.backup' "s:^USE_AEC=.*:USE_AEC=0:" makefile
-    sed -i'.backup' "s:\\\#define :\#define :g" makefile
 
     make lib
 

--- a/libs/build_wgrib2.sh
+++ b/libs/build_wgrib2.sh
@@ -39,7 +39,7 @@ cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
 URL="https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v${version}"
 
-[[ -d $software ]] || ( $WGET $URL; tar -xf wgrib2.tgz.v${version} )
+[[ -d $software || -f "wgrib2.tgz.v${version}" ]] || ( $WGET $URL )
 # wgrib2 is untarred as 'grib2'. Give a name with version.
 [[ -d $software ]] || mkdir $software && tar -xf wgrib2.tgz.v${version} -C $software --strip-components 1
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
@@ -71,13 +71,14 @@ sed -i'.backup' "s:^USE_REGEX=.*:USE_REGEX=${STACK_wgrib2_negex:-1}:" makefile
 sed -i'.backup' "s:^USE_TIGGE=.*:USE_TIGGE=${STACK_wgrib2_tigge:-1}:" makefile
 sed -i'.backup' "s:^USE_IPOLATES=.*:USE_IPOLATES=${STACK_wgrib2_ipolates:-3}:" makefile
 sed -i'.backup' "s:^USE_SPECTRAL=.*:USE_SPECTRAL=${STACK_wgrib2_spectral:-0}:" makefile
-sed -i'.backup' "s:^USE_UDF=.*:USE_AEC=${STACK_wgrib2_udf:-0}:" makefile
+sed -i'.backup' "s:^USE_UDF=.*:USE_UDF=${STACK_wgrib2_udf:-0}:" makefile
 sed -i'.backup' "s:^USE_JASPER=.*:USE_JASPER=${STACK_wgrib2_jasper:-1}:" makefile
 sed -i'.backup' "s:^USE_OPENMP=.*:USE_OPENMP=${STACK_wgrib2_openmp:-1}:" makefile
 sed -i'.backup' "s:^MAKE_FTN_API=.*:MAKE_FTN_API=${STACK_wgrib2_ftn_api:-1}:" makefile
 sed -i'.backup' "s:^USE_G2CLIB=.*:USE_G2CLIB=${STACK_wgrib2_g2clib:-0}:" makefile
 sed -i'.backup' "s:^USE_PNG=.*:USE_PNG=${STACK_wgrib2_png:-1}:" makefile
 sed -i'.backup' "s:^USE_AEC=.*:USE_AEC=${STACK_wgrib2_aec:-1}:" makefile
+sed -i'.backup' "s:\\\#define :\#define :g" makefile
 
 # Fix openmp flag in older version of wgrib2. Intel compilers no longer accept -openmp.
 sed -i'.backup' "s:-openmp:-qopenmp:" makefile
@@ -104,13 +105,14 @@ if [[ ${STACK_wgrib2_lib:-n} =~ [yYtT] ]]; then
     sed -i'.backup' "s:^USE_TIGGE=.*:USE_TIGGE=1:" makefile
     sed -i'.backup' "s:^USE_IPOLATES=.*:USE_IPOLATES=0:" makefile
     sed -i'.backup' "s:^USE_SPECTRAL=.*:USE_SPECTRAL=0:" makefile
-    sed -i'.backup' "s:^USE_UDF=.*:USE_AEC=0:" makefile
+    sed -i'.backup' "s:^USE_UDF=.*:USE_UDF=0:" makefile
     sed -i'.backup' "s:^USE_JASPER=.*:USE_JASPER=0:" makefile
     sed -i'.backup' "s:^USE_OPENMP=.*:USE_OPENMP=0:" makefile
     sed -i'.backup' "s:^MAKE_FTN_API=.*:MAKE_FTN_API=1:" makefile
     sed -i'.backup' "s:^USE_G2CLIB=.*:USE_G2CLIB=0:" makefile
     sed -i'.backup' "s:^USE_PNG=.*:USE_PNG=0:" makefile
     sed -i'.backup' "s:^USE_AEC=.*:USE_AEC=0:" makefile
+    sed -i'.backup' "s:\\\#define :\#define :g" makefile
 
     make lib
 

--- a/modulefiles/compiler/compilerName/compilerVersion/hpc-intel-oneapi-mpi/hpc-intel-oneapi-mpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hpc-intel-oneapi-mpi/hpc-intel-oneapi-mpi.lua
@@ -1,0 +1,30 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+conflict("hpc-cray-mpich","hpc-impi","hpc-intel-mpi","hpc-mpt","hpc-openmpi","hpc-mpich")
+
+local mpi = pathJoin("intel-oneapi-mpi",pkgVersion)
+load(mpi)
+prereq(mpi)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"intel-oneapi-mpi",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+setenv("MPI_FC",  "mpiifort")
+setenv("MPI_CC",  "mpiicc")
+setenv("MPI_CXX", "mpiicpc")
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: intel-oneapi-mpi Library and module access")

--- a/modulefiles/compiler/compilerName/compilerVersion/libpng/libpng.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/libpng/libpng.lua
@@ -15,15 +15,20 @@ local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 
-prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
-prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+local libdir = "lib"
+if (isFile(pathJoin(base,"lib64","libpng.a"))) then
+  libdir = "lib64"
+end
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,libdir))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,libdir))
 prepend_path("CPATH", pathJoin(base,"include"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 
 setenv("PNG_ROOT", base)
-setenv("LIBPNG_LIB", pathJoin(base,"${CMAKE_INSTALL_LIBDIR}","libpng.a"))
+setenv("LIBPNG_LIB", pathJoin(base,libdir,"libpng.a"))
 setenv("PNG_INCLUDES", pathJoin(base,"include"))
-setenv("PNG_LIBRARIES", pathJoin(base,"lib"))
+setenv("PNG_LIBRARIES", pathJoin(base,libdir))
 setenv("PNG_VERSION", pkgVersion)
 
 whatis("Name: ".. pkgName)

--- a/modulefiles/compiler/compilerName/compilerVersion/met/met.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/met/met.lua
@@ -19,6 +19,8 @@ prepend_path("PATH", pathJoin(base,"bin"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 
 setenv("MET_ROOT", base)
+setenv("MET_INSTALL_DIR", base)
+setenv("MET_BIN_EXEC", pathJoin(base, "bin"))
 setenv("MET_BASE", pathJoin(base, "share", "met"))
 setenv("MET_VERSION", pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/openblas/openblas.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/openblas/openblas.lua
@@ -1,0 +1,52 @@
+help([[OpenBLAS is an optimized Basic Linear Algebra Subprograms (BLAS) 
+library based on GotoBLAS2 1.13 BSD version.
+Software website - http://www.openblas.net/ ]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA = hierarchyA(pkgNameVer,1)
+local compNameVer = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+-- Set prerequisites and conflicts
+conflict("mkl")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+local libpath  = pathJoin(base,"lib")             -- libraries
+local incpath  = pathJoin(base,"include")         -- include files
+local pkgpath  = pathJoin(libpath,"pkgconfig")       -- pc files
+local libs     = "-lopenblas"
+
+-- Update path variables in user environment
+prepend_path("PKG_CONFIG_PATH", pkgpath)
+
+-- Configure NCAR compiler wrappers to use headers and libraries
+setenv("NCAR_ROOT_OPENBLAS", base)
+setenv("NCAR_INC_OPENBLAS", incpath)
+setenv("NCAR_LDFLAGS_OPENBLAS", libpath)
+setenv("NCAR_LIBS_OPENBLAS", libs)
+setenv("NCAR_ROOT_OPENBLAS", base)
+
+setenv("OPENBLAS_VERSION", pkgVersion)
+setenv("OPENBLAS_LIBS", libs)
+setenv("OPENBLAS_ROOT", base)
+setenv("OPENBLAS_INC", incpath)
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"man"))
+prepend_path("LIBRARY_PATH", libpath)
+prepend_path("LD_LIBRARY_PATH", libpath) 
+prepend_path("DYLD_LIBRARY_PATH", libpath) 
+prepend_path("CPATH", pathJoin(base,"include"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")
+

--- a/modulefiles/compiler/compilerName/compilerVersion/scotch/scotch.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/scotch/scotch.lua
@@ -1,0 +1,32 @@
+help([[Scotch is a software package for graph and mesh/hypergraph partitioning,
+graph clustering, and sparse matrix ordering.]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA = hierarchyA(pkgNameVer,1)
+local compNameVer = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"man"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("CMAKE_PREFIX_PATH", base)
+
+setenv("scotch_ROOT", base)
+setenv("scotch_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")

--- a/modulefiles/core/hpc-intel-classic/hpc-intel-classic.lua
+++ b/modulefiles/core/hpc-intel-classic/hpc-intel-classic.lua
@@ -1,0 +1,33 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+family("MetaCompiler")
+
+conflict(pkgName)
+conflict("hpc-gnu", "hpc-gcc","hpc-intel")
+
+local compiler = pathJoin("intel-classic",pkgVersion)
+load(compiler)
+prereq(compiler)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/compiler","intel-classic",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+setenv("FC",  "ifort")
+setenv("CC",  "icc")
+setenv("CXX", "icpc")
+
+setenv("SERIAL_FC",  "ifort")
+setenv("SERIAL_CC",  "icc")
+setenv("SERIAL_CXX", "icpc")
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Compiler")
+whatis("Description: Intel-classic Compiler Family and module access")
+

--- a/modulefiles/core/hpc-intel-oneapi-compilers/hpc-intel-oneapi-mpi.lua
+++ b/modulefiles/core/hpc-intel-oneapi-compilers/hpc-intel-oneapi-mpi.lua
@@ -1,0 +1,30 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+conflict("hpc-cray-mpich","hpc-impi","hpc-intel-mpi","hpc-mpt","hpc-openmpi","hpc-mpich")
+
+local mpi = pathJoin("intel-oneapi-mpi",pkgVersion)
+load(mpi)
+prereq(mpi)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"intel-oneapi-mpi",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+setenv("MPI_FC",  "mpiifort")
+setenv("MPI_CC",  "mpiicc")
+setenv("MPI_CXX", "mpiicpc")
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: intel-oneapi-mpi Library and module access")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/met/met.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/met/met.lua
@@ -1,0 +1,32 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"share","man"))
+
+setenv("MET_ROOT", base)
+setenv("MET_INSTALL_DIR", base)
+setenv("MET_BIN_EXEC", pathJoin(base, "bin"))
+setenv("MET_BASE", pathJoin(base, "share", "met"))
+setenv("MET_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: applications")
+whatis("Description: Model Evaluation Tools (MET)")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/metplus/metplus.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/metplus/metplus.lua
@@ -1,0 +1,29 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"ush"))
+
+setenv("METPLUS_ROOT", base)
+setenv("METPLUS_VERSION", pkgVersion)
+setenv("METPLUS_PATH", base)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: application")
+whatis("Description: Model Evaluation Tools Plus (METplus)")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/scotch/scotch.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/scotch/scotch.lua
@@ -1,0 +1,35 @@
+help([[Scotch is a software package for graph and mesh/hypergraph partitioning,
+graph clustering, and sparse matrix ordering.]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"man"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("CMAKE_PREFIX_PATH", base)
+
+setenv("scotch_ROOT", base)
+setenv("scotch_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")
+

--- a/stack/stack_comgsi.yaml
+++ b/stack/stack_comgsi.yaml
@@ -13,7 +13,7 @@ zlib:
 
 libpng:
   build: NO
-  version: 1.6.35
+  version: 1.6.37
 
 szip:
   build: NO
@@ -49,11 +49,11 @@ netcdf:
 
 nccmp:
   build: NO
-  version: 1.8.7.0
+  version: 1.8.9.0
 
 nco:
   build: NO
-  version: 4.9.3
+  version: 5.0.6
 
 cdo:
   build: NO
@@ -136,33 +136,33 @@ w3emc:
 
 g2:
   build: YES
-  version: v3.4.1
-  install_as: 3.4.1
+  version: v3.4.5
+  install_as: 3.4.4
   is_nceplib: YES
 
 g2c:
   build: YES
-  version: v1.6.2
-  install_as: 1.6.2
+  version: v1.6.4
+  install_as: 1.6.4
   is_nceplib: YES
 
 g2tmpl:
   build: YES
-  version: v1.9.1
-  install_as: 1.9.1
+  version: v1.10.2
+  install_as: 1.10.2
   is_nceplib: YES
 
 crtm:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.4.0
+  install_as: 2.4.0
   is_nceplib: YES
   install_fix: YES
 
 upp:
   build: NO
-  version: upp_v10.0.5
-  install_as: 10.0.5
+  version: upp_v10.0.10
+  install_as: 10.0.10
   openmp: ON
 
 wrf_io:
@@ -174,18 +174,17 @@ wrf_io:
 
 bufr:
   build: YES
-  version: bufr_v11.5.0
-  install_as: 11.5.0
+  version: bufr_v11.7.0
+  install_as: 11.7.0
   python: NO
   is_nceplib: YES
 
 wgrib2:
   build: NO
-  version: v2.0.8-cmake-v6
+  version: v2.0.8
   install_as: 2.0.8
-  openmp: ON
-  cmake_opts: "-DUSE_SPECTRAL=ON -DUSE_IPOLATES=3 -DUSE_NETCDF4=ON"
   is_nceplib: YES
+  ipolates: 3
 
 prod_util:
   build: NO
@@ -202,12 +201,12 @@ grib_util:
 
 ncio:
   build: NO
-  version: develop
-  install_as: 1.0.0
+  version: v1.1.2
+  install_as: 1.1.2
   is_nceplib: YES
 
 ncdiag:
   build: YES
-  version: v1.0.0
-  install_as: 1.0.0
+  version: v1.1.1
+  install_as: 1.1.1
   is_nceplib: YES

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -348,12 +348,13 @@ mapl:
 met:
   build: YES
   repo: DTCenter
-  version: 11.0.2
+  release_date: 20220516
+  version: 10.1.2
 
 metplus:
   build: YES
   repo: DTCenter
-  version: 5.0.2
+  version: 4.1.3
 
 geos:
   build: NO

--- a/stack/stack_custom.yaml
+++ b/stack/stack_custom.yaml
@@ -14,12 +14,12 @@ cmake:
 
 jpeg:
   build: YES
-  shared: YES
+  shared: NO
   version: 9.1.0
 
 zlib:
   build: YES
-  shared: YES
+  shared: NO
   version: 1.2.11
 
 libtiff:
@@ -246,8 +246,8 @@ ncio:
 
 ncdiag:
   build: YES
-  version: v1.0.0
-  install_as: 1.0.0
+  version: v1.1.1
+  install_as: 1.1.1
   is_nceplib: YES
 
 boost:
@@ -348,13 +348,12 @@ mapl:
 met:
   build: YES
   repo: DTCenter
-  release_date: 20220516
-  version: 10.1.2
+  version: 11.0.2
 
 metplus:
   build: YES
   repo: DTCenter
-  version: 4.1.3
+  version: 5.0.2
 
 geos:
   build: NO
@@ -392,3 +391,13 @@ ufswm:
   build: NO
   version: 1.0.0
   is_pyvenv: YES
+
+scotch:
+  build: YES
+  version: v7.0.3
+  install_as: 7.0.3
+
+openblas:
+  build: NO
+  version: 0.3.23
+

--- a/stack/stack_gaea.yaml
+++ b/stack/stack_gaea.yaml
@@ -16,7 +16,7 @@ zlib:
 libpng:
   build: YES
   shared: NO
-  version: 1.6.35
+  version: 1.6.37
 
 szip:
   build: YES
@@ -58,8 +58,8 @@ nccmp:
   version: 1.9.1.0
 
 nco:
-  build: NO
-  version: 4.9.3
+  build: YES
+  version: 5.0.6
 
 cdo:
   build: YES
@@ -67,23 +67,23 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.3
+  version: 2.5.7
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
   build: YES
-  version: ESMF_8_2_0
-  install_as: 8.2.0
-  shared: NO
+  version: v8.3.0b09
+  install_as: 8.3.0b09
+  shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
   build: YES
-  version: 2022.01
+  version: 2022.04
   repo: noaa-gfdl
-  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON"
+  cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DOPENMP=ON -DCONSTANTS=GFS"
 
 bacio:
   build: YES
@@ -174,21 +174,21 @@ g2c:
 
 g2tmpl:
   build: YES
-  version: v1.9.1
-  install_as: 1.9.1
+  version: v1.10.2
+  install_as: 1.10.2
   is_nceplib: YES
 
 crtm:
   build: YES
-  version: v2.3.0
-  install_as: 2.3.0
+  version: v2.4.0
+  install_as: 2.4.0
   is_nceplib: YES
   install_fix: NO
 
 upp:
   build: YES
-  version: upp_v10.0.9
-  install_as: 10.0.9
+  version: upp_v10.0.10
+  install_as: 10.0.10
   openmp: ON
 
 wrf_io:
@@ -200,9 +200,9 @@ wrf_io:
 
 bufr:
   build: YES
-  version: bufr_v11.5.0
-  install_as: 11.5.0
-  python: YES
+  version: bufr_v11.7.0
+  install_as: 11.7.0
+  python: NO
   is_nceplib: YES
 
 wgrib2:
@@ -227,14 +227,14 @@ grib_util:
 
 ncio:
   build: YES
-  version: v1.1.0
-  install_as: 1.1.0
+  version: v1.1.2
+  install_as: 1.1.2
   is_nceplib: YES
 
 ncdiag:
   build: YES
-  version: v1.0.0
-  install_as: 1.0.0
+  version: v1.1.1
+  install_as: 1.1.1
   is_nceplib: YES
 
 boost:
@@ -247,8 +247,12 @@ eigen:
   version: 3.3.7
 
 gsl_lite:
-  build: NO
+  build: YES
   version: 0.37.0
+
+gsl:
+  build: YES
+  version: 2.7.1
 
 gptl:
   build: NO
@@ -315,7 +319,7 @@ cmakemodules:
 gftl_shared:
   build: YES
   repo: Goddard-Fortran-Ecosystem
-  version: v1.3.0
+  version: v1.5.0
 
 yafyaml:
   build: YES
@@ -325,5 +329,24 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
-  esmf_version: 8.2.0
-  version: v2.7.3
+  esmf_version: 8.3.0b09
+  version: v2.22.0
+
+met:
+  build: YES
+  repo: DTCenter
+  version: 11.0.2
+
+metplus:
+  build: YES
+  repo: DTCenter
+  version: 5.0.2
+
+scotch:
+  build: YES
+  version: v7.0.3
+  install_as: 7.0.3
+
+openblas:
+  build: NO
+  version: 0.3.23

--- a/stack/stack_hera.yaml
+++ b/stack/stack_hera.yaml
@@ -1,3 +1,12 @@
+gnu:
+  build: NO
+  version: 12.1.0
+
+mpi:
+  build: NO
+  flavor: mpich
+  version: 3.3.2
+
 cmake:
   build: NO
   bootstrap: NO
@@ -55,7 +64,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.9.1.0
+  version: 1.8.9.0
 
 nco:
   build: YES
@@ -183,7 +192,7 @@ crtm:
   version: v2.4.0
   install_as: 2.4.0
   is_nceplib: YES
-  install_fix: YES
+  install_fix: NO
 
 upp:
   build: YES
@@ -229,6 +238,7 @@ ncio:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
+  build: YES
   is_nceplib: YES
 
 ncdiag:
@@ -236,11 +246,6 @@ ncdiag:
   version: v1.1.1
   install_as: 1.1.1
   is_nceplib: YES
-
-boost:
-  build: YES
-  version: 1.68.0
-  level: headers-only
 
 eigen:
   build: YES
@@ -298,7 +303,7 @@ fckit:
   repo: ecmwf
 
 atlas:
-  build: YES
+  build: NO
   version: 0.24.1
   repo: ecmwf
 
@@ -341,43 +346,6 @@ metplus:
   build: YES
   repo: DTCenter
   version: 5.0.2
-
-geos:
-  build: NO
-  version: 3.8.1
-
-sqlite:
-  build: NO
-  version: 3.32.3
-
-proj:
-  build: NO
-  version: 7.1.0
-  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
-
-miniconda3:
-  build: NO
-  version: 4.12.0
-
-r2d2:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-hofx:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-hofxdiag:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-ufswm:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
 
 scotch:
   build: YES

--- a/stack/stack_hera_gnu.yaml
+++ b/stack/stack_hera_gnu.yaml
@@ -1,3 +1,12 @@
+gnu:
+  build: NO
+  version: 12.1.0
+
+mpi:
+  build: NO
+  flavor: mpich
+  version: 3.3.2
+
 cmake:
   build: NO
   bootstrap: NO
@@ -55,7 +64,7 @@ netcdf:
 
 nccmp:
   build: YES
-  version: 1.9.1.0
+  version: 1.8.9.0
 
 nco:
   build: YES
@@ -183,7 +192,7 @@ crtm:
   version: v2.4.0
   install_as: 2.4.0
   is_nceplib: YES
-  install_fix: YES
+  install_fix: NO
 
 upp:
   build: YES
@@ -229,6 +238,7 @@ ncio:
   build: YES
   version: v1.1.2
   install_as: 1.1.2
+  build: YES
   is_nceplib: YES
 
 ncdiag:
@@ -236,11 +246,6 @@ ncdiag:
   version: v1.1.1
   install_as: 1.1.1
   is_nceplib: YES
-
-boost:
-  build: YES
-  version: 1.68.0
-  level: headers-only
 
 eigen:
   build: YES
@@ -342,48 +347,11 @@ metplus:
   repo: DTCenter
   version: 5.0.2
 
-geos:
-  build: NO
-  version: 3.8.1
-
-sqlite:
-  build: NO
-  version: 3.32.3
-
-proj:
-  build: NO
-  version: 7.1.0
-  cmake_opts: "-DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF"
-
-miniconda3:
-  build: NO
-  version: 4.12.0
-
-r2d2:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-hofx:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-hofxdiag:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
-ufswm:
-  build: NO
-  version: 1.0.0
-  is_pyvenv: YES
-
 scotch:
   build: YES
   version: v7.0.3
   install_as: 7.0.3
 
 openblas:
-  build: NO
+  build: YES
   version: 0.3.23

--- a/stack/stack_macos.yaml
+++ b/stack/stack_macos.yaml
@@ -1,11 +1,11 @@
 gnu:
   build: NO
-  version: 11.3.0
+  version: 12.3.0
 
 mpi:
   build: YES
   flavor: openmpi
-  version: 4.1.2
+  version: 4.1.5
 
 cmake:
   build: NO
@@ -18,7 +18,7 @@ jpeg:
 
 zlib:
   build: YES
-  version: 1.2.11
+  version: 1.2.13
 
 libpng:
   build: YES
@@ -38,22 +38,22 @@ udunits:
 
 hdf5:
   build: YES
-  version: 1.10.6
-  shared: YES
+  version: 1.14.0
+  shared: NO
   enable_szip: NO
   enable_zlib: YES
 
 pnetcdf:
   build: NO
   version: 1.12.1
-  shared: YES
+  shared: NO
 
 netcdf:
   build: YES
-  shared: YES
+  shared: NO
   enable_pnetcdf: NO
-  version_c: 4.7.4
-  version_f: 4.5.4
+  version_c: 4.9.2
+  version_f: 4.6.0
   version_cxx: 4.3.1
 
 nccmp:
@@ -70,21 +70,21 @@ cdo:
 
 pio:
   build: YES
-  version: 2.5.7
+  version: 2.5.10
   enable_pnetcdf: NO
   enable_gptl: NO
 
 esmf:
   build: YES
-  version: v8.3.0b09
-  install_as: 8.3.0b09
+  version: v8.4.2
+  install_as: 8.4.2
   shared: YES
   enable_pnetcdf: NO
   debug: NO
 
 fms:
   build: YES
-  version: 2022.04
+  version: 2023.01
   repo: noaa-gfdl
   cmake_opts: "-DGFS_PHYS=ON -D64BIT=ON -DENABLE_QUAD_PRECISION=OFF -DCONSTANTS=GFS "
 
@@ -186,7 +186,7 @@ crtm:
   version: v2.4.0
   install_as: 2.4.0
   is_nceplib: YES
-  install_fix: NO
+  install_fix: YES
 
 upp:
   build: YES
@@ -205,7 +205,7 @@ bufr:
   build: YES
   version: bufr_v11.7.0
   install_as: 11.7.0
-  python: YES
+  python: NO
   is_nceplib: YES
 
 wgrib2:
@@ -236,8 +236,8 @@ ncio:
 
 ncdiag:
   build: YES
-  version: v1.0.0
-  install_as: 1.0.0
+  version: v1.1.1
+  install_as: 1.1.1
   is_nceplib: YES
 
 boost:
@@ -333,8 +333,8 @@ yafyaml:
 mapl:
   build: YES
   repo: GEOS-ESM
-  version: v2.22.0
-  esmf_version: 8.3.0b09
+  version: v2.35.2
+  esmf_version: 8.4.2
 
 geos:
   build: NO
@@ -377,3 +377,12 @@ ufswm:
   build: NO
   version: 1.0.0
   is_pyvenv: YES
+
+scotch:
+  build: YES
+  version: v7.0.3
+  install_as: 7.0.3
+
+openblas:
+  build: YES
+  version: 0.3.23


### PR DESCRIPTION
Following updates were made: 

- CRTM/2.4.0 builds - updated installation option with MPI,  URL update for fix file locations, recipe for fix files installation (./libs/build_nceplibs.sh)
- Add/update scotch library build and modulefiles, serial and MPI options
- Add openblas library build and a modulefile
- Updated URL for building udunits
- Updated Met and Metplus installation scripts, URLs, and a modulefile for the met package
- ip build requires sp module loaded (build_nceplibs.sh)
- nccmp - a bug fixed in a directory name when untared
- setup_modules.sh - do not remove compiler and MPI requirements for meta-modules
- build_stack.sh script updated with building new libraries
- new options for compiler and MPI names in modulefiles
- ESMF build script - add parsing additional compiler and mpi names to set up ESMF env. variables
- updated libpng.lua modulefile to allow for lib64 library directory name
- build_nceplibs.sh - added options to build higher versions of prod_util, from different sources
- Updated README.md
